### PR TITLE
Add gitignore for Python caches and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Python caches and bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Editor swap files
+*~
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+
+# Archives
+*.tar
+*.gz
+*.zip
+
+# Logs
+*.log
+
+# Python virtual environments
+env/
+venv/
+.venv/
+
+# Distribution / build directories
+build/
+dist/
+
+# Coverage reports
+htmlcov/
+.coverage
+


### PR DESCRIPTION
## Summary
- add a `.gitignore` to exclude Python caches, editor swap files, archives, and other common generated artifacts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688450aaae648331a31fb4718f616d4d