### PR TITLE
Implement theme switcher and reader demo

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export type Theme = 'default' | 'dark' | 'earthy' | 'vibrant' | 'pastel';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme | ((t: Theme) => Theme)) => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(
+  undefined,
+);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = React.useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    return stored ?? 'default';
+  });
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ export interface HeaderProps {
     type: 'book' | 'author' | 'tag';
   }>;
   onSelectSuggestion?: (id: string, type: string) => void;
+  children?: React.ReactNode;
   className?: string;
   'data-testid'?: string;
 }
@@ -16,6 +17,7 @@ export const Header: React.FC<HeaderProps> = ({
   onSearch,
   suggestions,
   onSelectSuggestion,
+  children,
   className,
   'data-testid': dataTestId,
 }) => {
@@ -54,6 +56,7 @@ export const Header: React.FC<HeaderProps> = ({
           ))}
         </ul>
       )}
+      {children}
     </header>
   );
 };

--- a/src/components/ReaderDemo.tsx
+++ b/src/components/ReaderDemo.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ReaderToolbar } from './ReaderToolbar';
+import { ReaderView } from './ReaderView';
+import { ProgressBar } from './ProgressBar';
+import { useTheme } from '../ThemeProvider';
+
+const sampleHtml = `<h1>Chapter 1</h1><p>${'Lorem ipsum dolor sit amet, '.repeat(100)}</p>`;
+
+export const ReaderDemo: React.FC = () => {
+  const [percent, setPercent] = React.useState(0);
+  const [fontSize, setFontSize] = React.useState(16);
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="flex h-full flex-col">
+      <ReaderToolbar
+        title="Sample Book"
+        percent={Math.round(percent)}
+        onBack={() => {}}
+        onToggleTheme={() => setTheme(theme === 'dark' ? 'default' : 'dark')}
+        onFontSize={(d) =>
+          setFontSize((f) => Math.min(24, Math.max(12, f + d * 2)))
+        }
+        onBookmark={() => {}}
+      />
+      <ProgressBar value={percent} aria-label="Reading progress" />
+      <ReaderView
+        bookId="sample"
+        html={sampleHtml}
+        onPercentChange={setPercent}
+        style={{ fontSize }}
+        className="flex-1"
+      />
+    </div>
+  );
+};

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -7,6 +7,7 @@ export interface ReaderViewProps {
   initialPercent?: number;
   onPercentChange?: (pct: number) => void;
   onFinish?: () => void;
+  style?: React.CSSProperties;
   className?: string;
   'data-testid'?: string;
 }
@@ -23,6 +24,7 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
   initialPercent = 0,
   onPercentChange,
   onFinish,
+  style,
   className,
   'data-testid': dataTestId,
 }) => {
@@ -58,6 +60,7 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
     <div
       ref={ref}
       className={`overflow-y-auto p-4 ${className ?? ''}`}
+      style={style}
       dangerouslySetInnerHTML={{ __html: html }}
       data-testid={dataTestId}
     />

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTheme, Theme } from '../ThemeProvider';
+
+const themes: Theme[] = ['default', 'dark', 'earthy', 'vibrant', 'pastel'];
+
+export const ThemeSwitcher: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value as Theme)}
+      className="ml-2 rounded border p-1 text-sm"
+      aria-label="Theme"
+    >
+      {themes.map((t) => (
+        <option value={t} key={t}>
+          {t.charAt(0).toUpperCase() + t.slice(1)}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/src/designTokens.css
+++ b/src/designTokens.css
@@ -34,3 +34,33 @@
   --clr-text: #f3f4f6;
   --clr-text-muted: #b7bdc7;
 }
+[data-theme='earthy'] {
+  --clr-surface: #fbf8f3;
+  --clr-surface-alt: #f1eae1;
+  --clr-border: #e0d5c9;
+  --clr-text: #3d2b1f;
+  --clr-text-muted: #877567;
+  --clr-primary-700: #9a5f37;
+  --clr-primary-600: #b6703d;
+  --clr-primary-300: #dfbda3;
+}
+[data-theme='vibrant'] {
+  --clr-surface: #ffffff;
+  --clr-surface-alt: #fafafa;
+  --clr-border: #e5e5e5;
+  --clr-text: #1a1a1a;
+  --clr-text-muted: #555555;
+  --clr-primary-700: #ff0055;
+  --clr-primary-600: #ff3366;
+  --clr-primary-300: #ff99aa;
+}
+[data-theme='pastel'] {
+  --clr-surface: #fdfdfe;
+  --clr-surface-alt: #f5f5fa;
+  --clr-border: #e7e7f0;
+  --clr-text: #333344;
+  --clr-text-muted: #666688;
+  --clr-primary-700: #a489d4;
+  --clr-primary-600: #b9a5e6;
+  --clr-primary-300: #d8c8f2;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,16 +2,25 @@ import React from 'react';
 import { AppShell } from './AppShell';
 import { Header } from './components/Header';
 import { BottomNav } from './components/BottomNav';
+import { ThemeProvider } from './ThemeProvider';
+import { ThemeSwitcher } from './components/ThemeSwitcher';
+import { ReaderDemo } from './components/ReaderDemo';
 
 export const App: React.FC = () => {
   const [active, setActive] = React.useState<
     'discover' | 'library' | 'write' | 'activity' | 'profile'
   >('discover');
   return (
-    <AppShell>
-      <Header onSearch={() => {}} />
-      <main className="p-4">Hello, world!</main>
-      <BottomNav active={active} onChange={setActive} />
-    </AppShell>
+    <ThemeProvider>
+      <AppShell>
+        <Header onSearch={() => {}}>
+          <ThemeSwitcher />
+        </Header>
+        <main className="p-4">
+          {active === 'discover' ? <ReaderDemo /> : 'Hello, world!'}
+        </main>
+        <BottomNav active={active} onChange={setActive} />
+      </AppShell>
+    </ThemeProvider>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import { App } from './index';
+import { registerServiceWorker } from './registerSw';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(<App />);
+}
+
+registerServiceWorker();

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,6 +1,10 @@
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
-import { StaleWhileRevalidate, CacheFirst } from 'workbox-strategies';
+import {
+  StaleWhileRevalidate,
+  CacheFirst,
+  NetworkOnly,
+} from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { BackgroundSyncPlugin } from 'workbox-background-sync';
 
@@ -29,3 +33,9 @@ registerRoute(
 const bgSync = new BackgroundSyncPlugin('actions', {
   maxRetentionTime: 24 * 60,
 });
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/action'),
+  new NetworkOnly({ plugins: [bgSync] }),
+  'POST',
+);


### PR DESCRIPTION
## Summary
- add ThemeProvider with multiple themes
- allow switching themes via ThemeSwitcher in header
- create ReaderDemo page demonstrating reading progress & font scaling
- extend ReaderView for custom styles
- enable service worker background sync
- modernize React root rendering

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688461cae9e883318ccf9fda41f83b5c