### PR TITLE
Add zap support

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNostr, zap } from '../nostr';
 
 interface BookCardProps {
   event: {
@@ -13,6 +14,18 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
   const title = event.tags.find((t) => t[0] === 'title')?.[1] ?? 'Untitled';
   const summary = event.tags.find((t) => t[0] === 'summary')?.[1] ?? '';
   const cover = event.tags.find((t) => t[0] === 'image')?.[1];
+  const ctx = useNostr();
+  const [status, setStatus] = useState<'idle' | 'zapping' | 'done'>('idle');
+
+  const handleZap = async () => {
+    setStatus('zapping');
+    try {
+      await zap(ctx, event);
+      setStatus('done');
+    } catch {
+      setStatus('idle');
+    }
+  };
 
   return (
     <div className="rounded border p-2">
@@ -21,6 +34,18 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
       )}
       <h3 className="font-semibold">{title}</h3>
       {summary && <p className="text-sm text-gray-500">{summary}</p>}
+      <div className="pt-2">
+        <button
+          onClick={handleZap}
+          className="rounded bg-yellow-500 px-2 py-1 text-white"
+        >
+          {status === 'zapping'
+            ? 'Zapping...'
+            : status === 'done'
+              ? 'Zapped!'
+              : 'Zap'}
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement `zap` support in Nostr helpers
- show a zap button on each book card

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688476cbb87883318d0b2ec917a2bbc8