### PR TITLE
Add DMChat component

### DIFF
--- a/src/components/DMChat.tsx
+++ b/src/components/DMChat.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import type { Event as NostrEvent } from 'nostr-tools';
+import { useNostr, sendDM } from '../nostr';
+
+interface DM {
+  id: string;
+  from: string;
+  text: string;
+}
+
+interface DMChatProps {
+  to: string;
+  onClose?: () => void;
+}
+
+export const DMChat: React.FC<DMChatProps> = ({ to, onClose }) => {
+  const ctx = useNostr();
+  const { pubkey, subscribe } = ctx;
+  const [msgs, setMsgs] = useState<DM[]>([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (!pubkey) return;
+    const off = subscribe(
+      [
+        { kinds: [4], authors: [pubkey], '#p': [to], limit: 20 },
+        { kinds: [4], authors: [to], '#p': [pubkey], limit: 20 },
+      ],
+      (evt: NostrEvent) => {
+        (async () => {
+          const priv = localStorage.getItem('privKey');
+          if (!priv) return;
+          const other = evt.pubkey === pubkey ? to : evt.pubkey;
+          const plain = await (
+            await import('nostr-tools')
+          ).nip04.decrypt(priv, other, evt.content);
+          setMsgs((m) => [...m, { id: evt.id, from: evt.pubkey, text: plain }]);
+        })();
+      },
+    );
+    return off;
+  }, [subscribe, pubkey, to]);
+
+  const handleSend = async () => {
+    if (!text.trim()) return;
+    await sendDM(ctx, to, text);
+    setText('');
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="flex h-full w-full flex-col bg-[color:var(--clr-surface)] sm:m-4 sm:max-w-[360px] sm:rounded-md">
+        <div className="flex items-center justify-between border-b p-2">
+          <h2 className="text-lg font-medium">Chat</h2>
+          {onClose && (
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+            >
+              ×
+            </button>
+          )}
+        </div>
+        <div className="flex-1 space-y-2 overflow-y-auto p-2">
+          {msgs.map((m) => (
+            <div
+              key={m.id}
+              className={`rounded border p-2 ${m.from === pubkey ? 'self-end bg-primary-100' : 'self-start bg-[color:var(--clr-surface-alt)]'}`}
+            >
+              {m.text}
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2 border-t p-2">
+          <input
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            className="flex-1 rounded border p-2"
+            placeholder="Message"
+          />
+          <button
+            onClick={handleSend}
+            className="rounded bg-primary-600 px-3 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,18 +3,33 @@ import { AppShell } from './AppShell';
 import { Header } from './components/Header';
 import { BottomNav } from './components/BottomNav';
 import { ThemeProvider } from './ThemeProvider';
+import { DMChat } from './components/DMChat';
+import { useNostr } from './nostr';
 
 export const App: React.FC = () => {
   const [active, setActive] = React.useState<
     'discover' | 'library' | 'write' | 'activity' | 'profile'
   >('discover');
+  const [chatOpen, setChatOpen] = React.useState(false);
+  const { contacts } = useNostr();
 
   return (
     <ThemeProvider>
       <AppShell>
-        <Header onSearch={() => {}} />
+        <Header onSearch={() => {}}>
+          <button
+            onClick={() => setChatOpen(true)}
+            aria-label="Chat"
+            className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          >
+            💬
+          </button>
+        </Header>
         <main />
         <BottomNav active={active} onChange={setActive} />
+        {chatOpen && contacts[0] && (
+          <DMChat to={contacts[0]} onClose={() => setChatOpen(false)} />
+        )}
       </AppShell>
     </ThemeProvider>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,15 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { App } from './index';
 import { registerServiceWorker } from './registerSw';
+import { NostrProvider } from './nostr';
 
 const rootEl = document.getElementById('root');
 if (rootEl) {
-  createRoot(rootEl).render(<App />);
+  createRoot(rootEl).render(
+    <NostrProvider>
+      <App />
+    </NostrProvider>,
+  );
 }
 
 registerServiceWorker();


### PR DESCRIPTION
## Summary
- add DMChat component for encrypted messaging
- expose chat button in header and show DMChat
- wrap root rendering with `NostrProvider`

## Testing
- `npx prettier -w src/components/DMChat.tsx src/index.tsx src/main.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68847817d1288331adfe1dd2e712caa7