### PR TITLE
Add reading progress store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "nostr-tools": "^2.15.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@types/react": "^19.1.8",
@@ -324,7 +325,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1009,7 +1010,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4088,6 +4089,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "nostr-tools": "^2.15.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zustand": "^5.0.6"
   }
 }

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,48 +1,10 @@
 import React from 'react';
 import { useNostr } from '../nostr';
-
-interface LibraryItem {
-  id: string;
-  title: string;
-  author: string;
-  cover: string;
-  genre: string;
-  percent: number;
-  status: 'want' | 'reading' | 'finished';
-}
-
-const ITEMS: LibraryItem[] = [
-  {
-    id: '1',
-    title: 'Sample Book',
-    author: 'Author',
-    cover: 'https://placehold.co/56x84',
-    genre: 'Fiction',
-    percent: 50,
-    status: 'reading',
-  },
-  {
-    id: '2',
-    title: 'Next Book',
-    author: 'Writer',
-    cover: 'https://placehold.co/56x84',
-    genre: 'Nonfiction',
-    percent: 0,
-    status: 'want',
-  },
-  {
-    id: '3',
-    title: 'Finished Book',
-    author: 'Old Author',
-    cover: 'https://placehold.co/56x84',
-    genre: 'History',
-    percent: 100,
-    status: 'finished',
-  },
-];
+import { useReadingStore } from '../store';
 
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
+  const { books, finishBook, yearlyGoal, finishedCount } = useReadingStore();
   const [tab, setTab] = React.useState<'want' | 'reading' | 'finished'>(
     'reading',
   );
@@ -77,46 +39,54 @@ export const Library: React.FC = () => {
           </button>
         ))}
       </div>
+      <p className="mt-2 text-right text-[12px] text-[#B7BDC7]">
+        {finishedCount}/{yearlyGoal} books finished this year
+      </p>
       <div className="mt-4 space-y-2">
-        {ITEMS.filter(
-          (item) =>
-            item.status === tab &&
-            (contacts.length === 0 || contacts.includes(item.author)),
-        ).map((item) => (
-          <div
-            key={item.id}
-            className="mb-2 flex items-center gap-4 rounded-[8px] bg-[#262B33] p-3"
-          >
-            <img
-              src={item.cover}
-              alt=""
-              className="h-[84px] w-[56px] rounded-[4px] object-cover"
-            />
-            <div className="flex-1 space-y-1">
-              <h3 className="text-[16px] font-semibold leading-[24px]">
-                {item.title}
-              </h3>
-              <p className="text-[14px] leading-[20px] text-[#B7BDC7]">
-                {item.author}
-              </p>
-              <span className="inline-block rounded-[4px] bg-[#161A20] px-2 py-0.5 text-[12px] text-[#B7BDC7]">
-                {item.genre}
-              </span>
-              <div className="mt-1 h-1 rounded bg-[#262B33]">
-                <div
-                  className="h-full rounded bg-[#5A3999]"
-                  style={{ width: `${item.percent}%` }}
-                />
+        {books
+          .filter(
+            (item) =>
+              item.status === tab &&
+              (contacts.length === 0 || contacts.includes(item.author)),
+          )
+          .map((item) => (
+            <div
+              key={item.id}
+              className="mb-2 flex items-center gap-4 rounded-[8px] bg-[#262B33] p-3"
+            >
+              <img
+                src={item.cover}
+                alt=""
+                className="h-[84px] w-[56px] rounded-[4px] object-cover"
+              />
+              <div className="flex-1 space-y-1">
+                <h3 className="text-[16px] font-semibold leading-[24px]">
+                  {item.title}
+                </h3>
+                <p className="text-[14px] leading-[20px] text-[#B7BDC7]">
+                  {item.author}
+                </p>
+                <span className="inline-block rounded-[4px] bg-[#161A20] px-2 py-0.5 text-[12px] text-[#B7BDC7]">
+                  {item.genre}
+                </span>
+                <div className="mt-1 h-1 rounded bg-[#262B33]">
+                  <div
+                    className="h-full rounded bg-[#5A3999]"
+                    style={{ width: `${item.percent}%` }}
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-1 text-[12px] text-[#B7BDC7]">
+                <button
+                  onClick={() => finishBook(item.id)}
+                  className="rounded-[6px] bg-[#1F2228] px-3 py-1 text-[14px] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+                >
+                  Mark Finished
+                </button>
+                <span>{item.percent}%</span>
               </div>
             </div>
-            <div className="flex flex-col items-end gap-1 text-[12px] text-[#B7BDC7]">
-              <button className="rounded-[6px] bg-[#1F2228] px-3 py-1 text-[14px] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50">
-                Mark Finished
-              </button>
-              <span>{item.percent}%</span>
-            </div>
-          </div>
-        ))}
+          ))}
       </div>
     </div>
   );

--- a/src/components/ReaderModal.tsx
+++ b/src/components/ReaderModal.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { ReaderView } from './ReaderView';
 import { useTheme } from '../ThemeProvider';
+import { useReadingStore } from '../store';
 
 interface ReaderModalProps {
+  bookId: string;
   title: string;
   html: string;
   onClose: () => void;
 }
 
 export const ReaderModal: React.FC<ReaderModalProps> = ({
+  bookId,
   title,
   html,
   onClose,
@@ -16,6 +19,7 @@ export const ReaderModal: React.FC<ReaderModalProps> = ({
   const [fontSize, setFontSize] = React.useState(16);
   const [percent, setPercent] = React.useState(0);
   const { theme, setTheme } = useTheme();
+  const { updateProgress, finishBook } = useReadingStore();
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -65,11 +69,20 @@ export const ReaderModal: React.FC<ReaderModalProps> = ({
           className="flex-1 overflow-y-auto px-4 py-2 text-[#111214] dark:text-[#F3F4F6]"
           style={{ fontFamily: 'Georgia,serif', fontSize, lineHeight: '24px' }}
         >
-          <ReaderView html={html} onPercentChange={setPercent} />
+          <ReaderView
+            html={html}
+            onPercentChange={(p) => {
+              setPercent(p);
+              updateProgress(bookId, p);
+            }}
+          />
         </div>
         <div className="flex items-center justify-between px-4 py-3">
           <button
-            onClick={onClose}
+            onClick={() => {
+              finishBook(bookId);
+              onClose();
+            }}
             className="rounded-[6px] bg-[#E6E6EC] px-4 py-2 text-[14px] text-[#111214] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50 dark:bg-[#262B33] dark:text-[#F3F4F6]"
           >
             Mark as finished

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,92 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type BookStatus = 'want' | 'reading' | 'finished';
+
+export interface Book {
+  id: string;
+  title: string;
+  author: string;
+  cover: string;
+  genre: string;
+  percent: number;
+  status: BookStatus;
+}
+
+interface ReadingState {
+  books: Book[];
+  yearlyGoal: number;
+  finishedCount: number;
+  finishBook: (id: string) => void;
+  updateProgress: (id: string, percent: number) => void;
+  setYearlyGoal: (goal: number) => void;
+}
+
+const DEFAULT_BOOKS: Book[] = [
+  {
+    id: '1',
+    title: 'Sample Book',
+    author: 'Author',
+    cover: 'https://placehold.co/56x84',
+    genre: 'Fiction',
+    percent: 50,
+    status: 'reading',
+  },
+  {
+    id: '2',
+    title: 'Next Book',
+    author: 'Writer',
+    cover: 'https://placehold.co/56x84',
+    genre: 'Nonfiction',
+    percent: 0,
+    status: 'want',
+  },
+  {
+    id: '3',
+    title: 'Finished Book',
+    author: 'Old Author',
+    cover: 'https://placehold.co/56x84',
+    genre: 'History',
+    percent: 100,
+    status: 'finished',
+  },
+];
+
+export const useReadingStore = create<ReadingState>()(
+  persist(
+    (set, get) => ({
+      books: DEFAULT_BOOKS,
+      yearlyGoal: 12,
+      finishedCount: DEFAULT_BOOKS.filter((b) => b.status === 'finished')
+        .length,
+      finishBook: (id) =>
+        set((state) => {
+          const books = state.books.map((b) =>
+            b.id === id ? { ...b, status: 'finished', percent: 100 } : b,
+          );
+          const finishedCount = books.filter(
+            (b) => b.status === 'finished',
+          ).length;
+          return { books, finishedCount };
+        }),
+      updateProgress: (id, percent) =>
+        set((state) => {
+          const books = state.books.map((b) =>
+            b.id === id
+              ? {
+                  ...b,
+                  percent,
+                  status: percent >= 100 ? 'finished' : b.status,
+                }
+              : b,
+          );
+          const finishedCount = books.filter(
+            (b) => b.status === 'finished',
+          ).length;
+          return { books, finishedCount };
+        }),
+      setYearlyGoal: (goal) => set({ yearlyGoal: goal }),
+    }),
+    { name: 'reading-store' },
+  ),
+);


### PR DESCRIPTION
## Summary
- add Zustand store to track books and yearly progress
- show goal progress in the Library view
- save reading progress from ReaderModal and allow finishing
- mark items finished in Library

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no tests defined)*


------
https://chatgpt.com/codex/tasks/task_e_688479f5367883318edc39f1386a5a6d