### PR TITLE
Add onboarding tooltips

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
 import { BookCard } from './BookCard';
+import { useOnboarding } from '../useOnboarding';
 
 const TAGS = ['All', 'Fiction', 'Mystery', 'Fantasy'];
 
@@ -65,14 +66,21 @@ export const Discover: React.FC = () => {
 
   const recommended = filtered.slice(0, 6);
 
+  const searchOnboarding = useOnboarding('discover-search', 'Search for books');
+
   return (
     <div className="pb-4">
       <header className="relative bg-primary-600 py-3 text-center text-white">
         <button
+          ref={searchOnboarding.ref as React.RefObject<HTMLButtonElement>}
+          onClick={searchOnboarding.dismiss}
           aria-label="Search"
-          className="absolute left-2 top-1/2 -translate-y-1/2"
+          className={`relative absolute left-2 top-1/2 -translate-y-1/2 ${
+            searchOnboarding.show ? 'rounded ring-2 ring-primary-300' : ''
+          }`}
         >
           🔍
+          {searchOnboarding.Tooltip}
         </button>
         <h1 className="text-[18px] font-semibold">Bookstr</h1>
       </header>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNostr } from '../nostr';
 import { useReadingStore } from '../store';
+import { useOnboarding } from '../useOnboarding';
 
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
@@ -14,6 +15,11 @@ export const Library: React.FC = () => {
     { key: 'finished', label: 'Finished' },
   ];
 
+  const settingsOnboarding = useOnboarding(
+    'library-settings',
+    'Library settings',
+  );
+
   return (
     <div className="min-h-screen bg-[#0F1115] px-4 pb-4 text-white">
       <header
@@ -22,10 +28,14 @@ export const Library: React.FC = () => {
       >
         <h1 className="text-[20px] font-bold text-[#5A3999]">Bookstr</h1>
         <button
+          ref={settingsOnboarding.ref as React.RefObject<HTMLButtonElement>}
+          onClick={settingsOnboarding.dismiss}
           aria-label="Settings"
-          className="text-[#B7BDC7] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className={`relative text-[#B7BDC7] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50 ${
+            settingsOnboarding.show ? 'rounded ring-2 ring-primary-300' : ''
+          }`}
         >
-          ⚙
+          ⚙{settingsOnboarding.Tooltip}
         </button>
       </header>
       <div className="flex items-end gap-6" style={{ height: 48 }}>

--- a/src/useOnboarding.tsx
+++ b/src/useOnboarding.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export function useOnboarding(key: string, text: string) {
+  const [show, setShow] = React.useState(false);
+  const ref = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!localStorage.getItem(`onboard-${key}`)) {
+      setShow(true);
+    }
+  }, [key]);
+
+  const dismiss = React.useCallback(() => {
+    if (show) {
+      localStorage.setItem(`onboard-${key}`, '1');
+      setShow(false);
+    }
+  }, [show, key]);
+
+  const Tooltip =
+    show && ref.current ? (
+      <div className="pointer-events-none absolute z-10 mt-1 whitespace-nowrap rounded bg-primary-600 px-2 py-1 text-[12px] text-white shadow">
+        {text}
+      </div>
+    ) : null;
+
+  return { ref, show, dismiss, Tooltip };
+}


### PR DESCRIPTION
## Summary
- add a new `useOnboarding` hook that shows a tooltip once per user
- highlight search button in Discover
- highlight settings button in Library

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68847bb3549c8331a959abeeec0e3268