### PR TITLE
Add reader caching and offline action queueing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "idb-keyval": "^6.2.2",
         "nostr-tools": "^2.15.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2160,6 +2161,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "idb-keyval": "^6.2.2",
     "nostr-tools": "^2.15.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,12 @@
+export async function queueAction(action: Record<string, any>): Promise<void> {
+  try {
+    await fetch('/api/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(action),
+    });
+  } catch {
+    // errors are handled by BackgroundSync via service worker
+  }
+}
+

--- a/src/components/ReaderModal.tsx
+++ b/src/components/ReaderModal.tsx
@@ -3,6 +3,7 @@ import { ReaderView } from './ReaderView';
 import { useTheme } from '../ThemeProvider';
 import { useReadingStore } from '../store';
 import { Notes } from './Notes';
+import { queueAction } from '../actions';
 
 interface ReaderModalProps {
   bookId: string;
@@ -71,10 +72,12 @@ export const ReaderModal: React.FC<ReaderModalProps> = ({
           style={{ fontFamily: 'Georgia,serif', fontSize, lineHeight: '24px' }}
         >
           <ReaderView
+            bookId={bookId}
             html={html}
             onPercentChange={(p) => {
               setPercent(p);
               updateProgress(bookId, p);
+              queueAction({ type: 'progress', id: bookId, percent: p });
             }}
           />
           <Notes bookId={bookId} />
@@ -83,6 +86,7 @@ export const ReaderModal: React.FC<ReaderModalProps> = ({
           <button
             onClick={() => {
               finishBook(bookId);
+              queueAction({ type: 'finish', id: bookId });
               onClose();
             }}
             className="rounded-[6px] bg-[#E6E6EC] px-4 py-2 text-[14px] text-[#111214] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50 dark:bg-[#262B33] dark:text-[#F3F4F6]"

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { cacheBookHtml, getCachedBookHtml } from '../htmlCache';
 
 export interface ReaderViewProps {
   bookId: string;
@@ -19,6 +20,7 @@ function calcPercent(el: HTMLElement) {
 }
 
 export const ReaderView: React.FC<ReaderViewProps> = ({
+  bookId,
   html,
   scrollSync = true,
   initialPercent = 0,
@@ -29,6 +31,22 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
   'data-testid': dataTestId,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const [content, setContent] = useState(html);
+
+  useEffect(() => {
+    setContent(html);
+    if (html) {
+      cacheBookHtml(bookId, html);
+    }
+  }, [bookId, html]);
+
+  useEffect(() => {
+    if (!navigator.onLine && !html) {
+      getCachedBookHtml(bookId).then((cached) => {
+        if (cached) setContent(cached);
+      });
+    }
+  }, [bookId, html]);
 
   useEffect(() => {
     if (!ref.current) return;
@@ -61,7 +79,7 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
       ref={ref}
       className={`overflow-y-auto p-4 ${className ?? ''}`}
       style={style}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: content }}
       data-testid={dataTestId}
     />
   );

--- a/src/htmlCache.ts
+++ b/src/htmlCache.ts
@@ -1,0 +1,18 @@
+import { get, set } from 'idb-keyval';
+
+export async function cacheBookHtml(bookId: string, html: string): Promise<void> {
+  try {
+    await set(`html-${bookId}`, html);
+  } catch {
+    // ignore cache errors
+  }
+}
+
+export async function getCachedBookHtml(bookId: string): Promise<string | undefined> {
+  try {
+    return await get<string>(`html-${bookId}`);
+  } catch {
+    return undefined;
+  }
+}
+


### PR DESCRIPTION
## Summary
- install `idb-keyval`
- cache book HTML with `cacheBookHtml`/`getCachedBookHtml`
- enqueue progress/finish events via `queueAction`
- update `ReaderView` to save and retrieve HTML from IndexedDB
- hook background sync actions from `ReaderModal`

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68847c7d86508331a06364e380fc6fdb