### PR TITLE
Add analytics event logging

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,17 @@
+export async function logEvent(name: string, params: Record<string, unknown> = {}): Promise<void> {
+  try {
+    const gtag = (window as any).gtag;
+    if (typeof gtag === 'function') {
+      gtag('event', name, params);
+    } else {
+      await fetch('/api/event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, params }),
+        keepalive: true,
+      });
+    }
+  } catch {
+    // ignore analytics errors
+  }
+}

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNostr, zap } from '../nostr';
+import { logEvent } from '../analytics';
 
 interface BookCardProps {
   event: {
@@ -21,6 +22,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
     setStatus('zapping');
     try {
       await zap(ctx, event);
+      logEvent('book_zap', { id: event.id });
       setStatus('done');
     } catch {
       setStatus('idle');

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -3,6 +3,7 @@ import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
 import { BookCard } from './BookCard';
 import { useOnboarding } from '../useOnboarding';
+import { logEvent } from '../analytics';
 
 const TAGS = ['All', 'Fiction', 'Mystery', 'Fantasy'];
 
@@ -13,6 +14,10 @@ export const Discover: React.FC = () => {
   const voteIds = useRef(new Set<string>());
   const [search, setSearch] = useState('');
   const [tag, setTag] = useState('All');
+
+  useEffect(() => {
+    logEvent('discover_view');
+  }, []);
 
   useEffect(() => {
     const filters: Filter[] = [{ kinds: [30023], limit: 50 }];

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { cacheBookHtml, getCachedBookHtml } from '../htmlCache';
+import { logEvent } from '../analytics';
 
 export interface ReaderViewProps {
   bookId: string;
@@ -41,6 +42,10 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
   }, [bookId, html]);
 
   useEffect(() => {
+    logEvent('reader_open', { bookId });
+  }, [bookId]);
+
+  useEffect(() => {
     if (!navigator.onLine && !html) {
       getCachedBookHtml(bookId).then((cached) => {
         if (cached) setContent(cached);
@@ -64,7 +69,10 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
         window.requestAnimationFrame(() => {
           const pct = calcPercent(el);
           onPercentChange?.(pct);
-          if (pct >= 100) onFinish?.();
+          if (pct >= 100) {
+            logEvent('reader_finish', { bookId });
+            onFinish?.();
+          }
           ticking = false;
         });
         ticking = true;


### PR DESCRIPTION
## Summary
- add `analytics.ts` helper to send event data to Google Analytics or an API
- record a `discover_view` event on the Discover screen
- track zaps from `BookCard`
- log reader open and finish events from `ReaderView`

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68847d825564833192de662ce677c436