### PR TITLE
Add contacts manager and filter

### DIFF
--- a/src/components/ContactsManager.tsx
+++ b/src/components/ContactsManager.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useNostr } from '../nostr';
+
+/**
+ * Manage the list of followed pubkeys. Allows adding new contacts
+ * and removing existing ones. Updated lists are published via
+ * `saveContacts` from the nostr context.
+ */
+export const ContactsManager: React.FC = () => {
+  const { contacts, saveContacts } = useNostr();
+  const [input, setInput] = useState('');
+
+  const handleAdd = () => {
+    const pk = input.trim();
+    if (!pk) return;
+    if (contacts.includes(pk)) {
+      setInput('');
+      return;
+    }
+    saveContacts([...contacts, pk]);
+    setInput('');
+  };
+
+  const handleRemove = (pk: string) => {
+    saveContacts(contacts.filter((p) => p !== pk));
+  };
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-1">
+        {contacts.map((pk) => (
+          <li key={pk} className="flex items-center gap-2">
+            <span className="flex-1 break-all text-sm">{pk}</span>
+            <button
+              onClick={() => handleRemove(pk)}
+              className="text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-600/50"
+            >
+              Unfollow
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 rounded border p-2"
+          placeholder="Pubkey"
+        />
+        <button
+          onClick={handleAdd}
+          className="rounded bg-primary-600 px-3 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          Follow
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -6,13 +6,14 @@ import { useOnboarding } from '../useOnboarding';
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
   const { books, finishBook, yearlyGoal, finishedCount } = useReadingStore();
-  const [tab, setTab] = React.useState<'want' | 'reading' | 'finished'>(
-    'reading',
-  );
+  const [tab, setTab] = React.useState<
+    'want' | 'reading' | 'finished' | 'following'
+  >('reading');
   const tabs: Array<{ key: typeof tab; label: string }> = [
     { key: 'want', label: 'Want to Read' },
     { key: 'reading', label: 'Reading' },
     { key: 'finished', label: 'Finished' },
+    { key: 'following', label: 'Following' },
   ];
 
   const settingsOnboarding = useOnboarding(
@@ -54,11 +55,12 @@ export const Library: React.FC = () => {
       </p>
       <div className="mt-4 space-y-2">
         {books
-          .filter(
-            (item) =>
-              item.status === tab &&
-              (contacts.length === 0 || contacts.includes(item.author)),
-          )
+          .filter((item) => {
+            if (tab === 'following') {
+              return contacts.includes(item.author);
+            }
+            return item.status === tab;
+          })
           .map((item) => (
             <div
               key={item.id}

--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNostr, verifyNip05 } from '../nostr';
-import { FollowList } from './FollowList';
+import { ContactsManager } from './ContactsManager';
 
 interface ProfileMeta {
   [key: string]: unknown;
@@ -94,7 +94,7 @@ export const ProfileSettings: React.FC = () => {
       </button>
       <div className="pt-4">
         <h2 className="mb-2 text-sm font-medium">Following</h2>
-        <FollowList />
+        <ContactsManager />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new `ContactsManager` component to manage followed pubkeys
- embed the new manager in profile settings
- add a new "Following" tab in library filtered by contacts

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68848174682c83318f895de9f80b1a17