### PR TITLE
Implement reading progress sync

### DIFF
--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNostr } from '../nostr';
 import { useReadingStore } from '../store';
+import { ProgressBar } from './ProgressBar';
 import { useOnboarding } from '../useOnboarding';
 
 export const Library: React.FC = () => {
@@ -53,6 +54,11 @@ export const Library: React.FC = () => {
       <p className="mt-2 text-right text-[12px] text-[#B7BDC7]">
         {finishedCount}/{yearlyGoal} books finished this year
       </p>
+      <ProgressBar
+        value={Math.min(100, (finishedCount / yearlyGoal) * 100)}
+        aria-label="Yearly goal progress"
+        className="my-2"
+      />
       <div className="mt-4 space-y-2">
         {books
           .filter((item) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,7 @@ interface ReadingState {
   finishBook: (id: string) => void;
   updateProgress: (id: string, percent: number) => void;
   setYearlyGoal: (goal: number) => void;
+  loadStatuses: (entries: [string, BookStatus][]) => void;
 }
 
 const DEFAULT_BOOKS: Book[] = [
@@ -89,6 +90,23 @@ export const useReadingStore = create<ReadingState>()(
           return { books, finishedCount };
         }),
       setYearlyGoal: (goal) => set({ yearlyGoal: goal }),
+      loadStatuses: (entries) =>
+        set((state) => {
+          const books = state.books.map((b) => {
+            const entry = entries.find((e) => e[0] === b.id);
+            if (!entry) return b;
+            const status = entry[1];
+            return {
+              ...b,
+              status,
+              percent: status === 'finished' ? 100 : b.percent,
+            };
+          });
+          const finishedCount = books.filter(
+            (b) => b.status === 'finished',
+          ).length;
+          return { books, finishedCount };
+        }),
     }),
     { name: 'reading-store' },
   ),


### PR DESCRIPTION
## Summary
- store book status in zustand store
- sync library status with Nostr using kind `30001`
- display yearly goal progress bar in Library

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68848a8d25148331b6e05e4fce5f6641