### PR TITLE
Add basic analytics and event hooks

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,17 +1,33 @@
-export async function logEvent(name: string, params: Record<string, unknown> = {}): Promise<void> {
+interface EventRecord {
+  name: string;
+  params: Record<string, unknown>;
+  ts: number;
+}
+
+export async function logEvent(
+  name: string,
+  params: Record<string, unknown> = {},
+): Promise<void> {
+  const record: EventRecord = { name, params, ts: Date.now() };
+
   try {
-    const gtag = (window as any).gtag;
-    if (typeof gtag === 'function') {
-      gtag('event', name, params);
-    } else {
-      await fetch('/api/event', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, params }),
-        keepalive: true,
-      });
-    }
+    await fetch('/api/event', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+      keepalive: true,
+    });
   } catch {
-    // ignore analytics errors
+    // network failed, fall through to localStorage
+  }
+
+  try {
+    const stored = localStorage.getItem('analytics_events');
+    const events: EventRecord[] = stored ? JSON.parse(stored) : [];
+    events.push(record);
+    if (events.length > 100) events.shift();
+    localStorage.setItem('analytics_events', JSON.stringify(events));
+  } catch {
+    // ignore storage errors
   }
 }

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -13,15 +13,25 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
   const cover = event.tags.find((t) => t[0] === 'image')?.[1];
   const ctx = useNostr();
   const [status, setStatus] = useState<'idle' | 'zapping' | 'done'>('idle');
+  const { toggleBookmark, bookmarks } = ctx;
 
   const handleZap = async () => {
     setStatus('zapping');
     try {
       await zap(ctx, event);
-      logEvent('book_zap', { id: event.id });
+      logEvent('click_vote', { id: event.id });
       setStatus('done');
     } catch {
       setStatus('idle');
+    }
+  };
+
+  const handleFav = async () => {
+    try {
+      await toggleBookmark(event.id);
+      logEvent('click_fav', { id: event.id });
+    } catch {
+      /* ignore */
     }
   };
 
@@ -32,7 +42,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
       )}
       <h3 className="font-semibold">{title}</h3>
       {summary && <p className="text-sm text-gray-500">{summary}</p>}
-      <div className="pt-2">
+      <div className="pt-2 flex gap-2">
         <button
           onClick={handleZap}
           className="rounded bg-yellow-500 px-2 py-1 text-white"
@@ -42,6 +52,13 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
             : status === 'done'
               ? 'Zapped!'
               : 'Zap'}
+        </button>
+        <button
+          onClick={handleFav}
+          aria-label="Favorite"
+          className="rounded border px-2 py-1"
+        >
+          ★
         </button>
       </div>
     </div>

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -16,7 +16,7 @@ export const Discover: React.FC = () => {
   const [tag, setTag] = useState('All');
 
   useEffect(() => {
-    logEvent('discover_view');
+    logEvent('view_discover');
   }, []);
 
   useEffect(() => {

--- a/src/components/ReaderToolbar.tsx
+++ b/src/components/ReaderToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { logEvent } from '../analytics';
 
 export interface ReaderToolbarProps {
   title: string;
@@ -46,7 +47,14 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
     <button onClick={onToggleTheme} aria-label="Toggle theme" className="px-2">
       Theme
     </button>
-    <button onClick={onBookmark} aria-label="Bookmark" className="px-2">
+    <button
+      onClick={() => {
+        logEvent('click_fav');
+        onBookmark();
+      }}
+      aria-label="Bookmark"
+      className="px-2"
+    >
       ★
     </button>
     <span className="ml-2 text-sm text-text-muted">{percent}%</span>

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -71,6 +71,10 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
         window.requestAnimationFrame(() => {
           const pct = calcPercent(el);
           onPercentChange?.(pct);
+          logEvent('reader_percent_update', {
+            bookId,
+            percent: Math.round(pct),
+          });
           if (pct >= 100) {
             logEvent('reader_finish', { bookId });
             onFinish?.();


### PR DESCRIPTION
## Summary
- implement simple analytics recorder using localStorage and endpoint
- fire `view_discover` when Discover mounts
- track voting and favorite clicks in `BookCard`
- log favorites via ReaderToolbar
- emit reading progress updates in ReaderView

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68848cf23e408331b72197ee80d33f69