### PR TITLE
Add skeleton components and onboarding tooltip

### DIFF
--- a/src/components/BookCardSkeleton.tsx
+++ b/src/components/BookCardSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Skeleton, TextSkeleton } from './Skeleton';
+
+export const BookCardSkeleton: React.FC = () => (
+  <div className="rounded border p-2 space-y-2">
+    <Skeleton className="h-32 w-24" />
+    <TextSkeleton lines={1} className="w-3/4" />
+    <TextSkeleton lines={1} />
+    <div className="pt-2 flex gap-2">
+      <Skeleton className="h-6 w-16 rounded" />
+      <Skeleton className="h-6 w-8 rounded" />
+    </div>
+  </div>
+);

--- a/src/components/BookFeed.tsx
+++ b/src/components/BookFeed.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNostr } from '../nostr';
 import { BookCard } from './BookCard';
+import { BookCardSkeleton } from './BookCardSkeleton';
 import type { Event as NostrEvent } from 'nostr-tools';
 
 export const BookFeed: React.FC = () => {
@@ -16,9 +17,9 @@ export const BookFeed: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      {events.map((e) => (
-        <BookCard key={e.id} event={e} />
-      ))}
+      {events.length === 0
+        ? Array.from({ length: 3 }).map((_, i) => <BookCardSkeleton key={i} />)
+        : events.map((e) => <BookCard key={e.id} event={e} />)}
     </div>
   );
 };

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
 import { BookCard } from './BookCard';
-import { useOnboarding } from '../useOnboarding';
+import { BookCardSkeleton } from './BookCardSkeleton';
+import { OnboardingTooltip } from './OnboardingTooltip';
 import { logEvent } from '../analytics';
 
 const TAGS = ['All', 'Fiction', 'Mystery', 'Fantasy'];
@@ -72,22 +73,17 @@ export const Discover: React.FC = () => {
 
   const recommended = filtered.slice(0, 6);
 
-  const searchOnboarding = useOnboarding('discover-search', 'Search for books');
-
   return (
     <div className="pb-4">
       <header className="relative bg-primary-600 py-3 text-center text-white">
-        <button
-          ref={searchOnboarding.ref as React.RefObject<HTMLButtonElement>}
-          onClick={searchOnboarding.dismiss}
-          aria-label="Search"
-          className={`relative absolute left-2 top-1/2 -translate-y-1/2 ${
-            searchOnboarding.show ? 'rounded ring-2 ring-primary-300' : ''
-          }`}
-        >
-          🔍
-          {searchOnboarding.Tooltip}
-        </button>
+        <OnboardingTooltip storageKey="discover-search" text="Search for books">
+          <button
+            aria-label="Search"
+            className="relative absolute left-2 top-1/2 -translate-y-1/2"
+          >
+            🔍
+          </button>
+        </OnboardingTooltip>
         <h1 className="text-[18px] font-semibold">Bookstr</h1>
       </header>
       <div className="p-4">
@@ -116,25 +112,37 @@ export const Discover: React.FC = () => {
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Trending Books</h2>
         <div className="grid grid-cols-2 gap-4">
-          {trending.map((e) => (
-            <BookCard key={e.id} event={e as NostrEvent} />
-          ))}
+          {trending.length === 0
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <BookCardSkeleton key={i} />
+              ))
+            : trending.map((e) => (
+                <BookCard key={e.id} event={e as NostrEvent} />
+              ))}
         </div>
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">New Releases</h2>
         <div className="grid grid-cols-2 gap-4">
-          {newReleases.map((e) => (
-            <BookCard key={e.id} event={e as NostrEvent} />
-          ))}
+          {newReleases.length === 0
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <BookCardSkeleton key={i} />
+              ))
+            : newReleases.map((e) => (
+                <BookCard key={e.id} event={e as NostrEvent} />
+              ))}
         </div>
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Recommended for You</h2>
         <div className="grid grid-cols-2 gap-4">
-          {recommended.map((e) => (
-            <BookCard key={e.id} event={e as NostrEvent} />
-          ))}
+          {recommended.length === 0
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <BookCardSkeleton key={i} />
+              ))
+            : recommended.map((e) => (
+                <BookCard key={e.id} event={e as NostrEvent} />
+              ))}
         </div>
       </section>
     </div>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNostr } from '../nostr';
 import { useReadingStore } from '../store';
 import { ProgressBar } from './ProgressBar';
-import { useOnboarding } from '../useOnboarding';
+import { OnboardingTooltip } from './OnboardingTooltip';
 
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
@@ -17,11 +17,6 @@ export const Library: React.FC = () => {
     { key: 'following', label: 'Following' },
   ];
 
-  const settingsOnboarding = useOnboarding(
-    'library-settings',
-    'Library settings',
-  );
-
   return (
     <div className="min-h-screen bg-[#0F1115] px-4 pb-4 text-white">
       <header
@@ -29,16 +24,17 @@ export const Library: React.FC = () => {
         style={{ height: 56 }}
       >
         <h1 className="text-[20px] font-bold text-[#5A3999]">Bookstr</h1>
-        <button
-          ref={settingsOnboarding.ref as React.RefObject<HTMLButtonElement>}
-          onClick={settingsOnboarding.dismiss}
-          aria-label="Settings"
-          className={`relative text-[#B7BDC7] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50 ${
-            settingsOnboarding.show ? 'rounded ring-2 ring-primary-300' : ''
-          }`}
+        <OnboardingTooltip
+          storageKey="library-settings"
+          text="Library settings"
         >
-          ⚙{settingsOnboarding.Tooltip}
-        </button>
+          <button
+            aria-label="Settings"
+            className="text-[#B7BDC7] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          >
+            ⚙
+          </button>
+        </OnboardingTooltip>
       </header>
       <div className="flex items-end gap-6" style={{ height: 48 }}>
         {tabs.map((t) => (

--- a/src/components/OnboardingTooltip.tsx
+++ b/src/components/OnboardingTooltip.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useOnboarding } from '../useOnboarding';
+
+interface OnboardingTooltipProps {
+  storageKey: string;
+  text: string;
+  children: React.ReactElement;
+}
+
+export const OnboardingTooltip: React.FC<OnboardingTooltipProps> = ({
+  storageKey,
+  text,
+  children,
+}) => {
+  const { ref, show, dismiss, Tooltip } = useOnboarding(storageKey, text);
+
+  return React.cloneElement(children, {
+    ref,
+    onClick: (e: React.MouseEvent) => {
+      dismiss();
+      children.props.onClick?.(e);
+    },
+    className: `${children.props.className ?? ''} ${
+      show ? 'relative rounded ring-2 ring-primary-300' : ''
+    }`,
+    children: (
+      <>
+        {children.props.children}
+        {Tooltip}
+      </>
+    ),
+  });
+};

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className = '', ...props }, ref) => (
+    <div ref={ref} className={`skeleton ${className}`} {...props} />
+  ),
+);
+Skeleton.displayName = 'Skeleton';
+
+export const TextSkeleton: React.FC<
+  React.HTMLAttributes<HTMLDivElement> & { lines?: number }
+> = ({ lines = 1, className = '', ...props }) => (
+  <div className={className} {...props}>
+    {Array.from({ length: lines }).map((_, i) => (
+      <div key={i} className="skeleton mb-1 h-4 w-full last:mb-0" />
+    ))}
+  </div>
+);


### PR DESCRIPTION
## Summary
- implement generic `Skeleton` component and `BookCardSkeleton`
- display skeletons in `BookFeed` and `Discover` until data loads
- create `OnboardingTooltip` wrapper and use in Discover and Library

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68848e2960508331910ceba50c1a6367