### PR TITLE
Fix duplicate event handling in BookFeed

### DIFF
--- a/src/components/BookFeed.tsx
+++ b/src/components/BookFeed.tsx
@@ -10,7 +10,10 @@ export const BookFeed: React.FC = () => {
 
   useEffect(() => {
     const off = subscribe([{ kinds: [30023], limit: 20 }], (evt) =>
-      setEvents((e) => [...e, evt]),
+      setEvents((e) => {
+        if (e.find((x) => x.id === evt.id)) return e;
+        return [...e, evt];
+      }),
     );
     return off;
   }, [subscribe]);


### PR DESCRIPTION
## Summary
- avoid adding duplicate book events in `BookFeed`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688493a2ee70833191de3cb89b66f983