### PR TITLE
Add reaction button for voting

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNostr, zap } from '../nostr';
+import { ReactionButton } from './ReactionButton';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { logEvent } from '../analytics';
 
@@ -53,6 +54,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event }) => {
               ? 'Zapped!'
               : 'Zap'}
         </button>
+        <ReactionButton target={event.id} type="vote" />
         <button
           onClick={handleFav}
           aria-label="Favorite"

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNostr, publishVote, publishFavourite } from '../nostr';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+export interface ReactionButtonProps {
+  target: string;
+  type: 'vote' | 'favourite';
+  className?: string;
+}
+
+export const ReactionButton: React.FC<ReactionButtonProps> = ({
+  target,
+  type,
+  className,
+}) => {
+  const ctx = useNostr();
+  const [count, setCount] = useState(0);
+  const ids = useRef(new Set<string>());
+
+  useEffect(() => {
+    const symbol = type === 'vote' ? '+' : '★';
+    const off = ctx.subscribe(
+      [{ kinds: [7], '#e': [target] }],
+      (evt: NostrEvent) => {
+        if (evt.content === symbol && !ids.current.has(evt.id)) {
+          ids.current.add(evt.id);
+          setCount((c) => c + 1);
+        }
+      },
+    );
+    return off;
+  }, [ctx, target, type]);
+
+  const handleClick = async () => {
+    try {
+      if (type === 'vote') {
+        await publishVote(ctx, target);
+      } else {
+        await publishFavourite(ctx, target);
+      }
+    } catch {
+      /* ignore publish errors */
+    }
+  };
+
+  const label = type === 'vote' ? '+' : '★';
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={type === 'vote' ? 'Vote' : 'Favourite'}
+      className={`rounded border px-2 py-1 ${className ?? ''}`}
+    >
+      {label} {count > 0 ? count : ''}
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- add `ReactionButton` for voting and favourites
- display aggregated counts of kind `7` events
- show a reaction button on each `BookCard`

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68849774dda08331be8ab4fecd877522