### PR TITLE
Add follow button for Nostr contacts

### DIFF
--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { FollowButton } from './FollowButton';
+
+export interface AuthorCardProps {
+  pubkey: string;
+  name?: string;
+}
+
+/**
+ * Simple author card showing a name/pubkey with follow button.
+ */
+export const AuthorCard: React.FC<AuthorCardProps> = ({ pubkey, name }) => {
+  return (
+    <div className="flex items-center gap-2 rounded border p-2">
+      <div className="flex-1">
+        <p className="font-medium">{name || pubkey}</p>
+      </div>
+      <FollowButton pubkey={pubkey} />
+    </div>
+  );
+};

--- a/src/components/ContactsManager.tsx
+++ b/src/components/ContactsManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNostr } from '../nostr';
+import { AuthorCard } from './AuthorCard';
 
 /**
  * Manage the list of followed pubkeys. Allows adding new contacts
@@ -21,22 +22,12 @@ export const ContactsManager: React.FC = () => {
     setInput('');
   };
 
-  const handleRemove = (pk: string) => {
-    saveContacts(contacts.filter((p) => p !== pk));
-  };
-
   return (
     <div className="space-y-2">
       <ul className="space-y-1">
         {contacts.map((pk) => (
-          <li key={pk} className="flex items-center gap-2">
-            <span className="flex-1 break-all text-sm">{pk}</span>
-            <button
-              onClick={() => handleRemove(pk)}
-              className="text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-600/50"
-            >
-              Unfollow
-            </button>
+          <li key={pk}>
+            <AuthorCard pubkey={pk} />
           </li>
         ))}
       </ul>

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useNostr } from '../nostr';
+
+export interface FollowButtonProps {
+  pubkey: string;
+  className?: string;
+}
+
+/**
+ * Button that toggles following status for a given pubkey using
+ * the contacts list from the Nostr context.
+ */
+export const FollowButton: React.FC<FollowButtonProps> = ({
+  pubkey,
+  className,
+}) => {
+  const { contacts, saveContacts } = useNostr();
+  const following = contacts.includes(pubkey);
+
+  const toggle = () => {
+    const list = following
+      ? contacts.filter((p) => p !== pubkey)
+      : [...contacts, pubkey];
+    saveContacts(list);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className={
+        className ??
+        'rounded bg-primary-600 px-2 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50'
+      }
+    >
+      {following ? 'Unfollow' : 'Follow'}
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- add reusable `FollowButton` for toggling followed pubkeys
- add `AuthorCard` that displays a pubkey with the follow button
- extend `ContactsManager` to show `AuthorCard` for each followed account

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68849844e62c8331acb9e0d668817b3d