### PR TITLE
Add threaded comments support

### DIFF
--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -2,38 +2,61 @@ import React, { useEffect, useState } from 'react';
 import { useNostr } from '../nostr';
 import type { Event as NostrEvent } from 'nostr-tools';
 
-interface Props {
+interface CommentsProps {
   bookId: string;
+  parentEventId?: string;
+  events?: NostrEvent[];
 }
 
-export const Comments: React.FC<Props> = ({ bookId }) => {
-  const { subscribe, publishComment } = useNostr();
-  const [comments, setComments] = useState<NostrEvent[]>([]);
+export const Comments: React.FC<CommentsProps> = ({
+  bookId,
+  parentEventId,
+  events: initialEvents,
+}) => {
+  const { subscribe, publish } = useNostr();
+  const [events, setEvents] = useState<NostrEvent[]>(initialEvents ?? []);
   const [text, setText] = useState('');
 
   useEffect(() => {
+    if (initialEvents) return;
     const off = subscribe([{ kinds: [1], '#e': [bookId] }], (evt) =>
-      setComments((c) => [...c, evt]),
+      setEvents((c) => (c.find((e) => e.id === evt.id) ? c : [...c, evt])),
     );
     return off;
-  }, [subscribe, bookId]);
+  }, [subscribe, bookId, initialEvents]);
 
   const handleSend = async () => {
-    if (!text.trim()) return;
-    await publishComment(bookId, text);
+    const content = text.trim();
+    if (!content) return;
+
+    const tags: string[][] = [['e', bookId, '', 'root']];
+    if (parentEventId) {
+      tags.push(['e', parentEventId, '', 'reply']);
+      const parent = events.find((e) => e.id === parentEventId);
+      if (parent) tags.push(['p', parent.pubkey]);
+    }
+
+    await publish({ kind: 1, content, tags });
     setText('');
   };
 
+  const replies = events.filter((evt) => {
+    const parent = evt.tags.find((t) => t[0] === 'e' && t[3] === 'reply')?.[1];
+    return parentEventId ? parent === parentEventId : parent === undefined;
+  });
+
   return (
-    <div className="space-y-2">
-      {comments.map((c) => (
-        <div key={c.id} className="rounded border p-2">
-          {c.content}
+    <div className={`${parentEventId ? 'ml-4' : ''} space-y-2`}>
+      {replies.map((c) => (
+        <div key={c.id} className="space-y-2">
+          <div className="rounded border p-2">{c.content}</div>
+          <Comments bookId={bookId} parentEventId={c.id} events={events} />
         </div>
       ))}
       <textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
+        maxLength={200}
         className="w-full rounded border p-2"
         placeholder="Add comment"
       />


### PR DESCRIPTION
## Summary
- enable nesting and replying to comments
- include `e` and `p` tags on publish
- cap comment length at 200 characters

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68849cb212d4833191f1fec54a767b26