### PR TITLE
Add Nostr reporting button

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -3,6 +3,7 @@ import { useNostr, zap } from '../nostr';
 import { ReactionButton } from './ReactionButton';
 import { RepostButton } from './RepostButton';
 import { DeleteButton } from './DeleteButton';
+import { ReportButton } from './ReportButton';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { logEvent } from '../analytics';
 
@@ -64,6 +65,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         </button>
         <ReactionButton target={event.id} type="vote" />
         <RepostButton target={event.id} />
+        <ReportButton target={event.id} />
         <button
           onClick={handleFav}
           aria-label="Favorite"

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNostr } from '../nostr';
 import { DeleteButton } from './DeleteButton';
+import { ReportButton } from './ReportButton';
 import type { Event as NostrEvent } from 'nostr-tools';
 
 interface CommentsProps {
@@ -52,6 +53,7 @@ export const Comments: React.FC<CommentsProps> = ({
         <div key={c.id} className="space-y-2">
           <div className="rounded border p-2 flex items-start gap-2">
             <span className="flex-1">{c.content}</span>
+            <ReportButton target={c.id} />
             {pubkey === c.pubkey && (
               <DeleteButton
                 target={c.id}

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useNostr } from '../nostr';
+
+export interface ReportButtonProps {
+  target: string;
+  className?: string;
+}
+
+export const ReportButton: React.FC<ReportButtonProps> = ({ target, className }) => {
+  const { publish } = useNostr();
+
+  const handleClick = async () => {
+    const reason = window.prompt('Reason for report?');
+    const content = reason?.trim();
+    if (!content) return;
+    try {
+      await publish({ kind: 1985, content, tags: [['e', target]] });
+    } catch {
+      // ignore publish errors
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="Report"
+      className={`rounded border px-2 py-1 ${className ?? ''}`}
+    >
+      🚩
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- allow users to report posts and comments
- publish report events of kind `1985`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884a1c862948331b363c2b93ea0ac75