### PR TITLE
Add RelayListManager and dynamic relays

### DIFF
--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNostr, verifyNip05 } from '../nostr';
 import { ContactsManager } from './ContactsManager';
+import { RelayListManager } from './RelayListManager';
 
 interface ProfileMeta {
   [key: string]: unknown;
@@ -95,6 +96,10 @@ export const ProfileSettings: React.FC = () => {
       <div className="pt-4">
         <h2 className="mb-2 text-sm font-medium">Following</h2>
         <ContactsManager />
+      </div>
+      <div className="pt-4">
+        <h2 className="mb-2 text-sm font-medium">Relays</h2>
+        <RelayListManager />
       </div>
     </div>
   );

--- a/src/components/RelayListManager.tsx
+++ b/src/components/RelayListManager.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useNostr } from '../nostr';
+
+/**
+ * Manage the list of relay URLs. Allows adding new relays and
+ * removing existing ones. Updates are persisted using kind 10002
+ * events via `saveRelays` in the Nostr context.
+ */
+export const RelayListManager: React.FC = () => {
+  const { relays, saveRelays } = useNostr();
+  const [input, setInput] = useState('');
+
+  const handleAdd = () => {
+    const url = input.trim();
+    if (!url) return;
+    if (relays.includes(url)) {
+      setInput('');
+      return;
+    }
+    saveRelays([...relays, url]);
+    setInput('');
+  };
+
+  const handleRemove = (url: string) => {
+    saveRelays(relays.filter((r) => r !== url));
+  };
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-1">
+        {relays.map((r) => (
+          <li key={r} className="flex items-center gap-2">
+            <span className="flex-1 break-all">{r}</span>
+            <button
+              onClick={() => handleRemove(r)}
+              className="rounded bg-red-600 px-2 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 rounded border p-2"
+          placeholder="wss://relay.example"
+        />
+        <button
+          onClick={handleAdd}
+          className="rounded bg-primary-600 px-3 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add new `RelayListManager` component for editing relay URLs
- persist relay lists as kind `10002` events
- load and use these relays in `NostrProvider`
- expose relay settings in `ProfileSettings`

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6884a289ca308331a57ea920c2aee7e9