### PR TITLE
Add delegation tag generation and validation

### DIFF
--- a/src/components/DelegationManager.tsx
+++ b/src/components/DelegationManager.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { createDelegationTag } from '../nostr';
+
+/**
+ * Allow users to create delegation tags that authorize another
+ * pubkey to publish on their behalf. A simple form collects the
+ * delegatee pubkey, event kind and validity duration in days and
+ * outputs the generated tag so it can be shared with the delegatee.
+ */
+export const DelegationManager: React.FC = () => {
+  const [pubkey, setPubkey] = useState('');
+  const [kind, setKind] = useState('1');
+  const [days, setDays] = useState(30);
+  const [result, setResult] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    const priv = localStorage.getItem('privKey');
+    if (!priv || !pubkey) return;
+    const now = Math.floor(Date.now() / 1000);
+    const until = now + Number(days) * 86400;
+    const conditions = `kind=${kind}&created_at>${now}&created_at<${until}`;
+    const tag = createDelegationTag(priv, pubkey.trim(), conditions);
+    setResult(JSON.stringify(tag));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <input
+          value={pubkey}
+          onChange={(e) => setPubkey(e.target.value)}
+          placeholder="Delegate pubkey"
+          className="flex-1 rounded border p-2"
+        />
+        <input
+          type="number"
+          value={kind}
+          onChange={(e) => setKind(e.target.value)}
+          className="w-24 rounded border p-2"
+          placeholder="kind"
+        />
+        <input
+          type="number"
+          value={days}
+          onChange={(e) => setDays(Number(e.target.value))}
+          className="w-24 rounded border p-2"
+          placeholder="days"
+        />
+        <button
+          onClick={handleCreate}
+          className="rounded bg-primary-600 px-3 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          Create
+        </button>
+      </div>
+      {result && (
+        <textarea
+          readOnly
+          className="w-full rounded border p-2"
+          value={result}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNostr, verifyNip05 } from '../nostr';
 import { ContactsManager } from './ContactsManager';
 import { RelayListManager } from './RelayListManager';
+import { DelegationManager } from './DelegationManager';
 
 interface ProfileMeta {
   [key: string]: unknown;
@@ -100,6 +101,10 @@ export const ProfileSettings: React.FC = () => {
       <div className="pt-4">
         <h2 className="mb-2 text-sm font-medium">Relays</h2>
         <RelayListManager />
+      </div>
+      <div className="pt-4">
+        <h2 className="mb-2 text-sm font-medium">Delegations</h2>
+        <DelegationManager />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `DelegationManager` component for producing delegation tags
- integrate the new manager in `ProfileSettings`
- implement delegation utilities and validation inside `NostrProvider.publish`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884a3ed5b6c83318ac62bfd617ccfbc