### PR TITLE
Add community creation and feed

### DIFF
--- a/src/components/CommunityFeed.tsx
+++ b/src/components/CommunityFeed.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { useNostr } from '../nostr';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+export const CommunityFeed: React.FC = () => {
+  const { subscribe } = useNostr();
+  const [events, setEvents] = useState<NostrEvent[]>([]);
+
+  useEffect(() => {
+    const off = subscribe([{ kinds: [172], limit: 20 }], (evt) =>
+      setEvents((e) => {
+        if (e.find((x) => x.id === evt.id)) return e;
+        return [...e, evt];
+      }),
+    );
+    return off;
+  }, [subscribe]);
+
+  return (
+    <div className="space-y-4">
+      {events.map((evt) => {
+        const name = evt.tags.find((t) => t[0] === 'name')?.[1] || 'Unnamed';
+        return (
+          <div key={evt.id} className="rounded border p-2">
+            <h3 className="font-semibold">{name}</h3>
+            <p className="text-sm whitespace-pre-wrap">{evt.content}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/CommunityWizard.tsx
+++ b/src/components/CommunityWizard.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { useNostr } from '../nostr';
+
+export const CommunityWizard: React.FC = () => {
+  const { publish } = useNostr();
+  const [name, setName] = useState('');
+  const [about, setAbout] = useState('');
+
+  const handlePublish = async () => {
+    if (!name.trim()) return;
+    await publish({ kind: 172, content: about, tags: [['name', name]] });
+    setName('');
+    setAbout('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Community name"
+        className="w-full rounded border p-2"
+      />
+      <textarea
+        value={about}
+        onChange={(e) => setAbout(e.target.value)}
+        placeholder="Description"
+        className="w-full rounded border p-2"
+      />
+      <button
+        onClick={handlePublish}
+        className="rounded bg-primary-600 px-4 py-2 text-white"
+      >
+        Create
+      </button>
+    </div>
+  );
+};

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -5,6 +5,7 @@ import { BookCard } from './BookCard';
 import { BookCardSkeleton } from './BookCardSkeleton';
 import { OnboardingTooltip } from './OnboardingTooltip';
 import { logEvent } from '../analytics';
+import { CommunityFeed } from './CommunityFeed';
 
 const TAGS = ['All', 'Fiction', 'Mystery', 'Fantasy'];
 
@@ -190,6 +191,10 @@ export const Discover: React.FC = () => {
                 />
               ))}
         </div>
+      </section>
+      <section className="p-4">
+        <h2 className="mb-2 font-semibold">Communities</h2>
+        <CommunityFeed />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `CommunityWizard` component to publish kind 172 community events
- allow users to browse communities by subscribing to kind 172 events
- display communities section in Discover feed

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6884a652c87c833181554d6ccde42989