### PR TITLE
Add offline cache for book list

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -77,3 +77,21 @@ registerRoute(
     }
   },
 );
+
+registerRoute(
+  ({ url }) => url.pathname === '/books',
+  async ({ request }) => {
+    const cache = await caches.open('offline-pages');
+    try {
+      const response = await fetch(request);
+      if (response.ok) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    } catch {
+      const cached = await cache.match(request);
+      if (cached) return cached;
+      throw new Error('Network error');
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- allow the service worker to cache the `/books` list view so it works offline

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884b18881b48331aeaf58fc161a19d1