### PR TITLE
Switch privKey to memory

### DIFF
--- a/src/components/DMChat.tsx
+++ b/src/components/DMChat.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { Event as NostrEvent } from 'nostr-tools';
-import { useNostr, sendDM } from '../nostr';
+import { useNostr, sendDM, getPrivKey } from '../nostr';
 
 interface DM {
   id: string;
@@ -28,7 +28,7 @@ export const DMChat: React.FC<DMChatProps> = ({ to, onClose }) => {
       ],
       (evt: NostrEvent) => {
         (async () => {
-          const priv = localStorage.getItem('privKey');
+          const priv = getPrivKey();
           if (!priv) return;
           const other = evt.pubkey === pubkey ? to : evt.pubkey;
           const plain = await (

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { Event as NostrEvent } from 'nostr-tools';
-import { useNostr, sendDM } from '../nostr';
+import { useNostr, sendDM, getPrivKey } from '../nostr';
 
 interface Message {
   id: string;
@@ -28,7 +28,7 @@ export const DMModal: React.FC<DMModalProps> = ({ to, onClose }) => {
       ],
       (evt: NostrEvent) => {
         (async () => {
-          const priv = localStorage.getItem('privKey');
+          const priv = getPrivKey();
           if (!priv) return;
           const other = evt.pubkey === pubkey ? to : evt.pubkey;
           const plain = await (

--- a/src/components/DelegationManager.tsx
+++ b/src/components/DelegationManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { createDelegationTag } from '../nostr';
+import { createDelegationTag, getPrivKey } from '../nostr';
 
 /**
  * Allow users to create delegation tags that authorize another
@@ -14,7 +14,7 @@ export const DelegationManager: React.FC = () => {
   const [result, setResult] = useState<string | null>(null);
 
   const handleCreate = () => {
-    const priv = localStorage.getItem('privKey');
+    const priv = getPrivKey();
     if (!priv || !pubkey) return;
     const now = Math.floor(Date.now() / 1000);
     const until = now + Number(days) * 86400;

--- a/src/components/GroupChatModal.tsx
+++ b/src/components/GroupChatModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { Event as NostrEvent } from 'nostr-tools';
-import { useNostr, sendGroupDM } from '../nostr';
+import { useNostr, sendGroupDM, getPrivKey } from '../nostr';
 
 interface Message {
   id: string;
@@ -37,7 +37,7 @@ export const GroupChatModal: React.FC<GroupChatModalProps> = ({
       ],
       (evt: NostrEvent) => {
         (async () => {
-          const priv = localStorage.getItem('privKey');
+          const priv = getPrivKey();
           if (!priv) return;
           const all = [...others, pubkey];
           if (!hasAllRecipients(evt.tags as string[][], all)) return;


### PR DESCRIPTION
## Summary
- store private key only in memory
- persist derived pubkey separately
- update decryption helpers to use the new getter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884b93f61fc83318d15e4be2b58d0d9