### PR TITLE
Add private key validation with test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js",
+    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -4,6 +4,16 @@ import { useNostr } from '../nostr';
 export const Login: React.FC = () => {
   const { pubkey, login, logout } = useNostr();
   const [priv, setPriv] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleLogin = () => {
+    try {
+      login(priv);
+      setError(null);
+    } catch {
+      setError('Invalid private key');
+    }
+  };
 
   if (pubkey)
     return (
@@ -23,8 +33,9 @@ export const Login: React.FC = () => {
         className="w-full rounded border p-2"
         placeholder="Private key"
       />
+      {error && <div className="text-red-600">{error}</div>}
       <button
-        onClick={() => login(priv)}
+        onClick={handleLogin}
         className="rounded bg-primary-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
       >
         Login

--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -18,6 +18,7 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { buildCommentTags } from './commentUtils';
+import { validatePrivKey } from './validatePrivKey';
 
 const DEFAULT_RELAYS = [
   'wss://relay.damus.io',
@@ -225,6 +226,9 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [pubkey, relays]);
 
   const login = (priv: string) => {
+    if (!validatePrivKey(priv)) {
+      throw new Error('invalid private key');
+    }
     sessionPrivKey = priv;
     const pub = getPublicKey(hexToBytes(priv));
     localStorage.setItem('pubKey', pub);

--- a/src/validatePrivKey.ts
+++ b/src/validatePrivKey.ts
@@ -1,0 +1,3 @@
+export function validatePrivKey(key: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(key);
+}

--- a/test/validatePrivKey.test.js
+++ b/test/validatePrivKey.test.js
@@ -1,0 +1,9 @@
+require('ts-node/register');
+const assert = require('assert');
+const { validatePrivKey } = require('../src/validatePrivKey');
+
+assert.strictEqual(validatePrivKey('a'.repeat(63)), false);
+assert.strictEqual(validatePrivKey('g'.repeat(64)), false);
+assert.strictEqual(validatePrivKey('f'.repeat(64)), true);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- validate Nostr private keys before use
- show error message when login is attempted with an invalid key
- expose validation helper and test invalid key scenarios

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884bf6e38fc83318db26c4470289752