### PR TITLE
Add Nostr wallet auth helpers

### DIFF
--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -82,7 +82,7 @@ function leadingZeroBits(bytes: Uint8Array) {
   return count;
 }
 
-interface NostrContextValue {
+export interface NostrContextValue {
   pubkey: string | null;
   metadata: Record<string, unknown> | null;
   contacts: string[];
@@ -599,3 +599,5 @@ export async function zap(
     }, 30000);
   });
 }
+
+export { connectNostrWallet, nostrLogin } from './nostr/auth';

--- a/src/nostr/auth.ts
+++ b/src/nostr/auth.ts
@@ -1,0 +1,47 @@
+import type { Event, EventTemplate } from 'nostr-tools';
+import type { NostrContextValue } from '../nostr';
+
+/**
+ * Attempts to connect to a browser Nostr wallet via NIP-07.
+ * Returns the public key on success, otherwise `null`.
+ */
+export async function connectNostrWallet(): Promise<string | null> {
+  const nostr = (window as any).nostr;
+  if (!nostr || typeof nostr.getPublicKey !== 'function') return null;
+  try {
+    return await nostr.getPublicKey();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sign and publish a NIP-42 authentication event using a Nostr extension.
+ */
+export async function nostrLogin(
+  ctx: NostrContextValue,
+  pubkey: string,
+): Promise<string> {
+  const nostr = (window as any).nostr;
+  if (!nostr || typeof nostr.signEvent !== 'function') {
+    throw new Error('Nostr extension not available');
+  }
+
+  const challenge = Math.random().toString(36).slice(2);
+  const event: EventTemplate = {
+    kind: 22242,
+    content: '',
+    tags: [
+      ['challenge', challenge],
+    ],
+    pubkey,
+  } as any;
+
+  const signed: Event = await nostr.signEvent({
+    ...event,
+    created_at: Math.floor(Date.now() / 1000),
+  });
+
+  await ctx.sendEvent(signed);
+  return pubkey;
+}


### PR DESCRIPTION
## Summary
- export `NostrContextValue` type
- add `connectNostrWallet` and `nostrLogin` helpers
- re-export auth utilities from `src/nostr.tsx`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884c2abde408331a0ad10573a58e10c