### PR TITLE
Add NIP-07 login support

### DIFF
--- a/src/components/ChapterEditorModal.tsx
+++ b/src/components/ChapterEditorModal.tsx
@@ -60,7 +60,7 @@ export const ChapterEditorModal: React.FC<Props> = ({
     } else {
       ids[chapterNumber - 1] = evt.id;
     }
-    const tagsOut = [['d', bookId], ...ids.map((i) => ['e', i])];
+    const tagsOut = [['d', bookId], ...ids.map((i: string) => ['e', i])];
     await publish({ kind: 30001, content: '', tags: tagsOut });
     onClose();
   };

--- a/src/components/DMChat.tsx
+++ b/src/components/DMChat.tsx
@@ -29,11 +29,17 @@ export const DMChat: React.FC<DMChatProps> = ({ to, onClose }) => {
       (evt: NostrEvent) => {
         (async () => {
           const priv = getPrivKey();
-          if (!priv) return;
           const other = evt.pubkey === pubkey ? to : evt.pubkey;
-          const plain = await (
-            await import('nostr-tools')
-          ).nip04.decrypt(priv, other, evt.content);
+          let plain: string;
+          if (priv) {
+            plain = await (
+              await import('nostr-tools')
+            ).nip04.decrypt(priv, other, evt.content);
+          } else {
+            const nostr = (window as any).nostr;
+            if (!nostr?.nip04?.decrypt) return;
+            plain = await nostr.nip04.decrypt(other, evt.content);
+          }
           setMsgs((m) => [...m, { id: evt.id, from: evt.pubkey, text: plain }]);
         })();
       },

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -29,11 +29,17 @@ export const DMModal: React.FC<DMModalProps> = ({ to, onClose }) => {
       (evt: NostrEvent) => {
         (async () => {
           const priv = getPrivKey();
-          if (!priv) return;
           const other = evt.pubkey === pubkey ? to : evt.pubkey;
-          const plain = await (
-            await import('nostr-tools')
-          ).nip04.decrypt(priv, other, evt.content);
+          let plain: string;
+          if (priv) {
+            plain = await (
+              await import('nostr-tools')
+            ).nip04.decrypt(priv, other, evt.content);
+          } else {
+            const nostr = (window as any).nostr;
+            if (!nostr?.nip04?.decrypt) return;
+            plain = await nostr.nip04.decrypt(other, evt.content);
+          }
           setMsgs((m) => [...m, { id: evt.id, from: evt.pubkey, text: plain }]);
         })();
       },

--- a/src/nostr/auth.ts
+++ b/src/nostr/auth.ts
@@ -43,5 +43,6 @@ export async function nostrLogin(
   });
 
   await ctx.sendEvent(signed);
+  if (ctx.loginNip07) ctx.loginNip07(pubkey);
   return pubkey;
 }


### PR DESCRIPTION
## Summary
- track NIP-07 logins in `NostrProvider`
- sign and encrypt messages with browser extension when no local key
- handle NIP-07 logins in authentication helper
- support encrypted message decryption via extension
- fix `ChapterEditorModal` typing

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6884c8d0ec4c8331bac2d683c652989a