### PR TITLE
Add nostr auth tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js",
+    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js && node test/auth.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,41 @@
+require('ts-node/register');
+const assert = require('assert');
+const { connectNostrWallet, nostrLogin } = require('../src/nostr/auth');
+
+(async () => {
+  // connectNostrWallet returns key
+  global.window = { nostr: { getPublicKey: async () => 'npub1' } };
+  const key = await connectNostrWallet();
+  assert.strictEqual(key, 'npub1');
+
+  // connectNostrWallet handles missing wallet
+  global.window = {};
+  const noKey = await connectNostrWallet();
+  assert.strictEqual(noKey, null);
+
+  // nostrLogin throws when signEvent missing
+  await assert.rejects(() => nostrLogin({ sendEvent: async () => {} }, 'npub1'));
+
+  // nostrLogin publishes signed challenge once
+  let sendCount = 0;
+  let sentEvent;
+  const ctx = {
+    sendEvent: async (ev) => {
+      sendCount++; sentEvent = ev;
+    },
+    loginNip07: () => {},
+  };
+  let signEventInput;
+  global.window = {
+    nostr: {
+      signEvent: async (ev) => { signEventInput = ev; return { ...ev, id: '1', sig: 'sig' }; },
+    },
+  };
+  const resKey = await nostrLogin(ctx, 'npub1');
+  assert.strictEqual(resKey, 'npub1');
+  assert.strictEqual(sendCount, 1);
+  assert.deepStrictEqual(sentEvent, { ...signEventInput, id: '1', sig: 'sig' });
+  assert.ok(signEventInput.tags.find((t) => t[0] === 'challenge'));
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add tests for `connectNostrWallet` and `nostrLogin`
- run the new test in the npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884cb923f0c833193ca384f13d32f9c