### PR TITLE
Add basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js && node test/auth.test.js",
+    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -1,0 +1,23 @@
+require('ts-node/register');
+const assert = require('assert');
+const { queueAction } = require('../src/actions');
+
+(async () => {
+  let args;
+  global.fetch = async (...a) => {
+    args = a;
+    return {};
+  };
+  await queueAction({ foo: 'bar' });
+  assert.strictEqual(args[0], '/api/action');
+  assert.strictEqual(args[1].method, 'POST');
+  assert.strictEqual(args[1].headers['Content-Type'], 'application/json');
+  assert.strictEqual(args[1].body, JSON.stringify({ foo: 'bar' }));
+
+  global.fetch = async () => {
+    throw new Error('fail');
+  };
+  await queueAction({ hello: 'world' });
+
+  console.log('All tests passed.');
+})();

--- a/test/registerSw.test.js
+++ b/test/registerSw.test.js
@@ -1,0 +1,16 @@
+require('ts-node/register');
+const assert = require('assert');
+const { registerServiceWorker } = require('../src/registerSw');
+
+(async () => {
+  let called = null;
+  navigator.serviceWorker = { register: (url) => { called = url; } };
+  global.window = { addEventListener: (ev, cb) => { if (ev === 'load') cb(); } };
+  registerServiceWorker();
+  assert.strictEqual(called, '/sw.js');
+
+  delete navigator.serviceWorker;
+  registerServiceWorker();
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- expand `npm test` to include new test files
- add regression test for the `queueAction` helper
- add service worker registration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68853d0e51d483319f475d598b3ecee0