### PR TITLE
Add env config for relays and API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ docker run -e PORT=8080 -p 8080:8080 bookstr:latest
 This starts the API server on port 8080 while still serving the compiled web
 app.
 
+### Environment Variables
+
+The frontend reads certain configuration from Vite environment variables:
+
+- `VITE_RELAY_URLS` – comma separated list of default Nostr relay URLs.
+- `VITE_API_BASE` – base path for API requests (defaults to `/api`).
+
+The API server also honours `API_BASE` to match the frontend and `PORT` for
+the listening port.
+
 ### Zap Flow (NIP-57)
 
 Bookstr implements lightning zaps following [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md). The flow is:

--- a/server/index.js
+++ b/server/index.js
@@ -3,15 +3,16 @@ const express = require('express');
 const app = express();
 
 const PORT = process.env.PORT || 3000;
+const API_BASE = process.env.API_BASE || '/api';
 
 app.use(express.json());
 
-app.post('/api/action', (req, res) => {
+app.post(`${API_BASE}/action`, (req, res) => {
   console.log('action', req.body);
   res.json({ status: 'ok' });
 });
 
-app.post('/api/event', (req, res) => {
+app.post(`${API_BASE}/event`, (req, res) => {
   console.log('event', req.body);
   res.json({ status: 'ok' });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,8 @@
+const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
+
 export async function queueAction(action: Record<string, any>): Promise<void> {
   try {
-    await fetch('/api/action', {
+    await fetch(`${API_BASE}/action`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(action),

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -4,6 +4,8 @@ interface EventRecord {
   ts: number;
 }
 
+const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
+
 export async function logEvent(
   name: string,
   params: Record<string, unknown> = {},
@@ -11,7 +13,7 @@ export async function logEvent(
   const record: EventRecord = { name, params, ts: Date.now() };
 
   try {
-    await fetch('/api/event', {
+    await fetch(`${API_BASE}/event`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(record),

--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -21,11 +21,16 @@ import { sha256 } from '@noble/hashes/sha256';
 import { buildCommentTags } from './commentUtils';
 import { validatePrivKey } from './validatePrivKey';
 
-const DEFAULT_RELAYS = [
-  'wss://relay.damus.io',
-  'wss://relay.primal.net',
-  'wss://nostr.wine',
-];
+const DEFAULT_RELAYS = ((import.meta as any).env?.VITE_RELAY_URLS as string | undefined)
+  ? ((import.meta as any).env.VITE_RELAY_URLS as string)
+      .split(',')
+      .map((r) => r.trim())
+      .filter(Boolean)
+  : [
+      'wss://relay.damus.io',
+      'wss://relay.primal.net',
+      'wss://nostr.wine',
+    ];
 
 const encoder = new TextEncoder();
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -11,6 +11,8 @@ import { getOfflineBooks } from './offlineStore';
 
 declare let self: ServiceWorkerGlobalScope;
 
+const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
+
 precacheAndRoute(self.__WB_MANIFEST || []);
 
 registerRoute(
@@ -27,7 +29,7 @@ registerRoute(
 );
 
 registerRoute(
-  ({ url }) => url.pathname.startsWith('/api/'),
+  ({ url }) => url.pathname.startsWith(`${API_BASE}/`),
   new StaleWhileRevalidate({ cacheName: 'api' }),
 );
 
@@ -36,7 +38,7 @@ const bgSync = new BackgroundSyncPlugin('actions', {
 });
 
 registerRoute(
-  ({ url }) => url.pathname.startsWith('/api/action'),
+  ({ url }) => url.pathname.startsWith(`${API_BASE}/action`),
   new NetworkOnly({ plugins: [bgSync] }),
   'POST',
 );


### PR DESCRIPTION
## Summary
- allow configuring API base path via `VITE_API_BASE`
- allow configuring default relay list via `VITE_RELAY_URLS`
- document new environment variables
- update service worker and server to respect API base

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885473b66d08331bfd33df738860547