### PR TITLE
Fix registerSw tests

### DIFF
--- a/src/registerSw.ts
+++ b/src/registerSw.ts
@@ -1,5 +1,5 @@
 export function registerServiceWorker() {
-  if ('serviceWorker' in navigator) {
+  if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js');
     });

--- a/test/registerSw.test.js
+++ b/test/registerSw.test.js
@@ -3,8 +3,9 @@ const assert = require('assert');
 const { registerServiceWorker } = require('../src/registerSw');
 
 (async () => {
+  if (!global.navigator) global.navigator = {};
   let called = null;
-  navigator.serviceWorker = { register: (url) => { called = url; } };
+  global.navigator.serviceWorker = { register: (url) => { called = url; } };
   global.window = { addEventListener: (ev, cb) => { if (ev === 'load') cb(); } };
   registerServiceWorker();
   assert.strictEqual(called, '/sw.js');


### PR DESCRIPTION
## Summary
- fix registerSw.ts to check navigator exists
- create global.navigator in registerSw.test.js when not present
- run test suite with Node 20

## Testing
- `nvm use 20`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68854a32f33c83318c71774ad588ee78