### PR TITLE
Implement search suggestions

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
+import { useSearchParams } from 'react-router-dom';
 import { BookCard } from './BookCard';
 import { BookCardSkeleton } from './BookCardSkeleton';
 import { OnboardingTooltip } from './OnboardingTooltip';
@@ -11,13 +12,27 @@ const TAGS = ['All', 'Fiction', 'Mystery', 'Fantasy'];
 
 export const Discover: React.FC = () => {
   const { subscribe, contacts } = useNostr();
+  const [params, setParams] = useSearchParams();
   const [events, setEvents] = useState<
     (NostrEvent & { repostedBy?: string })[]
   >([]);
   const [votes, setVotes] = useState<Record<string, number>>({});
   const voteIds = useRef(new Set<string>());
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(params.get('q') || '');
   const [tag, setTag] = useState('All');
+
+  useEffect(() => {
+    const q = params.get('q') || '';
+    setSearch(q);
+  }, [params]);
+
+  const updateSearch = (val: string) => {
+    setSearch(val);
+    const next = new URLSearchParams(params);
+    if (val) next.set('q', val);
+    else next.delete('q');
+    setParams(next);
+  };
 
   useEffect(() => {
     logEvent('view_discover');
@@ -122,7 +137,7 @@ export const Discover: React.FC = () => {
       <div className="p-4">
         <input
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => updateSearch(e.target.value)}
           placeholder="Search"
           className="w-full rounded border border-border p-2 focus-visible:outline-none focus-visible:[box-shadow:var(--focus-ring)]"
         />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,19 +22,40 @@ export const Header: React.FC<HeaderProps> = ({
   'data-testid': dataTestId,
 }) => {
   const [q, setQ] = React.useState('');
+  const [active, setActive] = React.useState(-1);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!suggestions || suggestions.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((a) => (a + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((a) => (a - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === 'Enter' && active >= 0) {
+      e.preventDefault();
+      const s = suggestions[active];
+      onSelectSuggestion?.(s.id, s.type);
+    }
+  };
 
   return (
     <header className={className} data-testid={dataTestId} role="search">
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          onSearch(q);
+          onSelectSuggestion?.(q, 'search');
         }}
         className="flex items-center gap-2 p-2"
       >
         <input
           value={q}
-          onChange={(e) => setQ(e.target.value)}
+          onChange={(e) => {
+            const val = e.target.value;
+            setQ(val);
+            onSearch(val);
+          }}
+          onKeyDown={handleKeyDown}
           className="flex-1 rounded border p-2"
           placeholder="Search"
         />
@@ -44,11 +65,13 @@ export const Header: React.FC<HeaderProps> = ({
           role="listbox"
           className="bg-[color:var(--clr-surface-alt)] shadow-1"
         >
-          {suggestions.map((s) => (
+          {suggestions.map((s, i) => (
             <li
               key={s.id}
               role="option"
-              className="p-2 hover:bg-primary-300 cursor-pointer"
+              className={`p-2 hover:bg-primary-300 cursor-pointer ${
+                active === i ? 'bg-primary-300' : ''
+              }`}
               onMouseDown={() => onSelectSuggestion?.(s.id, s.type)}
             >
               {s.label}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { Header } from './components/Header';
+import { search, Suggestion } from './search';
 import { BottomNav } from './components/BottomNav';
 import { ThemeProvider } from './ThemeProvider';
 import { DMModal } from './components/DMModal';
@@ -41,6 +42,23 @@ const AppRoutes: React.FC = () => {
   }, [location.pathname]);
   const [chatOpen, setChatOpen] = React.useState(false);
   const { contacts } = useNostr();
+  const [suggestions, setSuggestions] = React.useState<Suggestion[]>([]);
+
+  const handleSearch = async (q: string) => {
+    const res = await search(q);
+    setSuggestions(res);
+  };
+
+  const handleSelectSuggestion = (id: string, type: string) => {
+    setSuggestions([]);
+    if (type === 'book') {
+      navigate(`/book/${id}`);
+    } else if (type === 'search') {
+      navigate(`/discover?q=${encodeURIComponent(id)}`);
+    } else {
+      navigate(`/discover?${type}=${encodeURIComponent(id)}`);
+    }
+  };
 
   const handleChange = (key: typeof active) => {
     navigate(`/${key}`);
@@ -48,7 +66,11 @@ const AppRoutes: React.FC = () => {
 
   return (
     <AppShell>
-      <Header onSearch={() => {}}>
+      <Header
+        onSearch={handleSearch}
+        suggestions={suggestions}
+        onSelectSuggestion={handleSelectSuggestion}
+      >
         <button
           onClick={() => setChatOpen(true)}
           aria-label="Chat"

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,34 @@
+export interface Suggestion {
+  id: string;
+  label: string;
+  type: 'book' | 'author' | 'tag';
+}
+
+const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
+
+export async function search(q: string): Promise<Suggestion[]> {
+  if (!q) return [];
+  try {
+    const res = await fetch(`${API_BASE}/search?q=${encodeURIComponent(q)}`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    const books = (data.books || []).map((b: any) => ({
+      id: b.id,
+      label: b.title,
+      type: 'book' as const,
+    }));
+    const authors = (data.authors || []).map((a: any) => ({
+      id: a.id,
+      label: a.name,
+      type: 'author' as const,
+    }));
+    const tags = (data.tags || []).map((t: any) => ({
+      id: t.id ?? t.tag ?? t,
+      label: t.tag ?? t.label ?? t,
+      type: 'tag' as const,
+    }));
+    return [...books, ...authors, ...tags];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- implement `search` utility to query backend/relays
- hook header search into new `search` and show results
- add keyboard navigation to suggestion dropdown
- sync `Discover` search with URL params

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885500dfed483318c52af1d256ae325