### PR TITLE
Add configurable offline book caching

### DIFF
--- a/src/useSettings.ts
+++ b/src/useSettings.ts
@@ -6,9 +6,15 @@ export type Density = 'comfortable' | 'compact';
 export interface SettingsState {
   textSize: number;
   density: Density;
+  offlineMaxBooks: number;
   setTextSize: (size: number) => void;
   setDensity: (d: Density) => void;
-  hydrate: (data: Partial<Pick<SettingsState, 'textSize' | 'density'>>) => void;
+  setOfflineMaxBooks: (n: number) => void;
+  hydrate: (
+    data: Partial<
+      Pick<SettingsState, 'textSize' | 'density' | 'offlineMaxBooks'>
+    >,
+  ) => void;
 }
 
 export const useSettings = create<SettingsState>()(
@@ -16,8 +22,10 @@ export const useSettings = create<SettingsState>()(
     (set) => ({
       textSize: 16,
       density: 'comfortable',
+      offlineMaxBooks: 3,
       setTextSize: (textSize) => set({ textSize }),
       setDensity: (density) => set({ density }),
+      setOfflineMaxBooks: (offlineMaxBooks) => set({ offlineMaxBooks }),
       hydrate: (data) => set(data),
     }),
     { name: 'settings-store' },


### PR DESCRIPTION
## Summary
- allow configuration of offline book cache limit via `useSettings`
- update `offlineStore` with removal helpers and limit logic
- add offline content controls to profile settings
- refresh service worker cache when offline list changes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68855511cca88331b92e567e0d3cc8f8