### PR TITLE
Add alt text to book cover images

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -59,7 +59,11 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         </p>
       )}
       {cover && (
-        <img src={cover} alt="" className="mb-2 h-32 w-24 object-cover" />
+        <img
+          src={cover}
+          alt={`Cover image for ${title}`}
+          className="mb-2 h-32 w-24 object-cover"
+        />
       )}
       <h3 className="font-semibold">{title}</h3>
       {summary && <p className="text-sm text-gray-500">{summary}</p>}

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -134,7 +134,13 @@ export const BookPublishWizard: React.FC = () => {
       {step === 4 && (
         <div className="space-y-2">
           <h2 className="text-lg font-semibold">{title}</h2>
-          {cover && <img src={cover} alt="" className="max-h-40 w-auto" />}
+          {cover && (
+            <img
+              src={cover}
+              alt={title ? `Cover image for ${title}` : 'Book cover'}
+              className="max-h-40 w-auto"
+            />
+          )}
           <p>{summary}</p>
           <div className="flex flex-wrap gap-1">
             {tags

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -70,7 +70,7 @@ export const Library: React.FC = () => {
             >
               <img
                 src={item.cover}
-                alt=""
+                alt={`Cover image for ${item.title}`}
                 className="h-[84px] w-[56px] rounded-[4px] object-cover"
               />
               <div className="flex-1 space-y-1">

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -84,7 +84,11 @@ export const BookDetailScreen: React.FC = () => {
       {meta && (
         <div className="space-y-2">
           {meta.cover && (
-            <img src={meta.cover} alt="" className="h-32 w-auto" />
+            <img
+              src={meta.cover}
+              alt={`Cover image for ${meta.title}`}
+              className="h-32 w-auto"
+            />
           )}
           <h2 className="text-xl font-semibold">{meta.title}</h2>
           {meta.summary && <p>{meta.summary}</p>}

--- a/src/screens/BookListScreen.tsx
+++ b/src/screens/BookListScreen.tsx
@@ -78,7 +78,13 @@ export const BookListScreen: React.FC = () => {
             className="rounded border p-2 cursor-pointer"
             onClick={() => navigate(`/book/${b.id}`)}
           >
-            {b.cover && <img src={b.cover} alt="" className="h-24 w-auto" />}
+            {b.cover && (
+              <img
+                src={b.cover}
+                alt={`Cover image for ${b.title}`}
+                className="h-24 w-auto"
+              />
+            )}
             <h3 className="font-semibold">{b.title}</h3>
             {b.summary && <p className="text-sm">{b.summary}</p>}
           </div>


### PR DESCRIPTION
## Summary
- provide informative alt text for book cover images in BookPublishWizard, Library, BookCard, BookListScreen, and BookDetailScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855a254cb88331aba3b6f312789636