### PR TITLE
Use icons for reactions and favorites

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -4,6 +4,7 @@ import { ReactionButton } from './ReactionButton';
 import { RepostButton } from './RepostButton';
 import { DeleteButton } from './DeleteButton';
 import { ReportButton } from './ReportButton';
+import { FaHeart } from 'react-icons/fa';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { logEvent } from '../analytics';
 
@@ -97,7 +98,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
           aria-label="Favorite"
           className="rounded border px-2 py-1"
         >
-          ★
+          <FaHeart className="inline" />
         </button>
         {pubkey === event.pubkey && (
           <DeleteButton

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { FaThumbsUp, FaStar } from 'react-icons/fa';
 import { useNostr, publishVote, publishFavourite } from '../nostr';
 import type { Event as NostrEvent } from 'nostr-tools';
 
@@ -47,7 +48,7 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
     }
   };
 
-  const label = type === 'vote' ? '+' : '★';
+  const icon = type === 'vote' ? <FaThumbsUp className="inline" /> : <FaStar className="inline" />;
 
   return (
     <button
@@ -55,7 +56,7 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
       aria-label={type === 'vote' ? 'Vote' : 'Favourite'}
       className={`rounded border px-2 py-1 ${active ? 'border-primary-600 bg-primary-600 text-white' : ''} ${className ?? ''}`}
     >
-      {label} {count > 0 ? count : ''}
+      {icon} {count > 0 ? count : ''}
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- replace text symbols in `ReactionButton` with `FaThumbsUp` and `FaStar`
- use a `FaHeart` icon for favorites in `BookCard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855c3d7d3083318f9dbb5c1b6a794b