### PR TITLE
Add Notification feed

### DIFF
--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { FaAt, FaReply, FaUserPlus, FaBolt } from 'react-icons/fa';
+import type { Event as NostrEvent } from 'nostr-tools';
+import { useNostr } from '../nostr';
+
+type Notification = {
+  id: string;
+  type: 'mention' | 'reply' | 'follow' | 'zap';
+  event: NostrEvent;
+  link?: string;
+};
+
+export const NotificationFeed: React.FC = () => {
+  const { pubkey, subscribe } = useNostr();
+  const [items, setItems] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    if (!pubkey) return;
+    const offs: Array<() => void> = [];
+
+    // Mentions and replies
+    offs.push(
+      subscribe([{ kinds: [1], '#p': [pubkey], limit: 20 }], (evt) => {
+        if (evt.pubkey === pubkey) return;
+        const isReply = evt.tags.some((t) => t[0] === 'e' && t[3] === 'reply');
+        const bookId =
+          evt.tags.find((t) => t[0] === 'e' && t[3] === 'root')?.[1] ??
+          evt.tags.find((t) => t[0] === 'e')?.[1];
+        const link = bookId ? `/book/${bookId}` : undefined;
+        const type = isReply ? 'reply' : 'mention';
+        setItems((n) =>
+          n.find((x) => x.id === evt.id)
+            ? n
+            : [...n, { id: evt.id, type, event: evt, link }],
+        );
+      }),
+    );
+
+    // Follows
+    offs.push(
+      subscribe([{ kinds: [3], '#p': [pubkey], limit: 20 }], (evt) => {
+        if (evt.pubkey === pubkey) return;
+        setItems((n) =>
+          n.find((x) => x.id === evt.id)
+            ? n
+            : [
+                ...n,
+                { id: evt.id, type: 'follow', event: evt, link: '/profile' },
+              ],
+        );
+      }),
+    );
+
+    // Zaps
+    offs.push(
+      subscribe([{ kinds: [9735], '#p': [pubkey], limit: 20 }], (evt) => {
+        if (evt.pubkey === pubkey) return;
+        const bookId = evt.tags.find((t) => t[0] === 'e')?.[1];
+        const link = bookId ? `/book/${bookId}` : undefined;
+        setItems((n) =>
+          n.find((x) => x.id === evt.id)
+            ? n
+            : [...n, { id: evt.id, type: 'zap', event: evt, link }],
+        );
+      }),
+    );
+
+    return () => {
+      offs.forEach((off) => off());
+    };
+  }, [subscribe, pubkey]);
+
+  const iconMap = {
+    mention: <FaAt aria-label="Mention" />,
+    reply: <FaReply aria-label="Reply" />,
+    follow: <FaUserPlus aria-label="Follow" />,
+    zap: <FaBolt aria-label="Zap" />,
+  } as const;
+
+  return (
+    <div className="space-y-2">
+      {items.map((n) => (
+        <div key={n.id} className="flex items-center gap-2 rounded border p-2">
+          <span>{iconMap[n.type]}</span>
+          {n.link ? (
+            <Link to={n.link} className="text-blue-600 underline">
+              {n.type === 'follow'
+                ? 'New follower'
+                : n.type === 'zap'
+                  ? 'Zap received'
+                  : n.type === 'reply'
+                    ? 'New reply'
+                    : 'Mentioned you'}
+            </Link>
+          ) : (
+            <span>
+              {n.type === 'follow'
+                ? 'New follower'
+                : n.type === 'zap'
+                  ? 'Zap received'
+                  : n.type === 'reply'
+                    ? 'New reply'
+                    : 'Mentioned you'}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import { BookDetailScreen } from './screens/BookDetailScreen';
 import { Discover } from './components/Discover';
 import { Library } from './components/Library';
 import { BookPublishWizard } from './components/BookPublishWizard';
-import { CommunityFeed } from './components/CommunityFeed';
+import { NotificationFeed } from './components/NotificationFeed';
 import { ProfileSettings } from './components/ProfileSettings';
 
 const AppRoutes: React.FC = () => {
@@ -84,7 +84,7 @@ const AppRoutes: React.FC = () => {
           <Route path="/discover" element={<Discover />} />
           <Route path="/library" element={<Library />} />
           <Route path="/write" element={<BookPublishWizard />} />
-          <Route path="/activity" element={<CommunityFeed />} />
+          <Route path="/activity" element={<NotificationFeed />} />
           <Route path="/profile" element={<ProfileSettings />} />
           <Route path="/books" element={<BookListScreen />} />
           <Route path="/book/:bookId" element={<BookDetailScreen />} />


### PR DESCRIPTION
## Summary
- add a new `NotificationFeed` component to display mention, reply, follow and zap events for the logged in user
- replace the `/activity` route content with the new feed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68856306529c833188c27bdcf61f5d33