### PR TITLE
Add simple achievements tracking

### DIFF
--- a/src/achievements.ts
+++ b/src/achievements.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type AchievementId = 'first-publish' | 'five-finished';
+
+interface AchievementState {
+  unlocked: AchievementId[];
+  unlock: (id: AchievementId) => void;
+}
+
+export const useAchievements = create<AchievementState>()(
+  persist(
+    (set) => ({
+      unlocked: [],
+      unlock: (id) =>
+        set((state) =>
+          state.unlocked.includes(id)
+            ? state
+            : { unlocked: [...state.unlocked, id] },
+        ),
+    }),
+    { name: 'achievement-store' },
+  ),
+);
+
+export const ACHIEVEMENT_LABELS: Record<AchievementId, string> = {
+  'first-publish': 'First Book Published',
+  'five-finished': '5 Books Finished',
+};
+
+export function reportBookPublished(): void {
+  useAchievements.getState().unlock('first-publish');
+}
+
+export function reportFinishedCount(count: number): void {
+  if (count >= 5) {
+    useAchievements.getState().unlock('five-finished');
+  }
+}

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
 import { useNostr, publishLongPost } from '../nostr';
 import DOMPurify from 'dompurify';
+import { reportBookPublished } from '../achievements';
 
 export interface BookPublishWizardProps {
   onPublish?: (id: string) => void;
@@ -48,6 +49,7 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
     setTags('');
     setContent('');
     setPow(false);
+    reportBookPublished();
     if (onPublish) onPublish(evt.id);
   };
 

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -3,10 +3,21 @@ import { useNostr } from '../nostr';
 import { useReadingStore } from '../store';
 import { ProgressBar } from './ProgressBar';
 import { OnboardingTooltip } from './OnboardingTooltip';
+import {
+  useAchievements,
+  ACHIEVEMENT_LABELS,
+  AchievementId,
+} from '../achievements';
+import { FaPen, FaTrophy } from 'react-icons/fa';
 
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
   const { books, finishBook, yearlyGoal, finishedCount } = useReadingStore();
+  const { unlocked } = useAchievements();
+  const iconMap: Record<AchievementId, JSX.Element> = {
+    'first-publish': <FaPen />,
+    'five-finished': <FaTrophy />,
+  };
   const [tab, setTab] = React.useState<
     'want' | 'reading' | 'finished' | 'following'
   >('reading');
@@ -55,6 +66,19 @@ export const Library: React.FC = () => {
         aria-label="Yearly goal progress"
         className="my-2"
       />
+      {unlocked.length > 0 && (
+        <div className="mt-2 flex gap-2">
+          {unlocked.map((id) => (
+            <span
+              key={id}
+              title={ACHIEVEMENT_LABELS[id]}
+              className="text-primary-600 text-lg"
+            >
+              {iconMap[id]}
+            </span>
+          ))}
+        </div>
+      )}
       <div className="mt-4 space-y-2">
         {books
           .filter((item) => {

--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -8,6 +8,12 @@ import { DelegationManager } from './DelegationManager';
 import { ThemeSwitcher } from './ThemeSwitcher';
 import { useReadingStore } from '../store';
 import {
+  useAchievements,
+  ACHIEVEMENT_LABELS,
+  AchievementId,
+} from '../achievements';
+import { FaPen, FaTrophy } from 'react-icons/fa';
+import {
   getOfflineBooks,
   saveOfflineBook,
   removeOfflineBook,
@@ -39,6 +45,11 @@ export const ProfileSettings: React.FC = () => {
   const [verified, setVerified] = React.useState<boolean | null>(null);
 
   const { books, yearlyGoal, setYearlyGoal } = useReadingStore();
+  const { unlocked } = useAchievements();
+  const iconMap: Record<AchievementId, JSX.Element> = {
+    'first-publish': <FaPen />,
+    'five-finished': <FaTrophy />,
+  };
   const offlineMaxBooks = useSettings((s) => s.offlineMaxBooks);
   const setOfflineMaxBooks = useSettings((s) => s.setOfflineMaxBooks);
   const [offlineBooks, setOfflineBooks] = React.useState<OfflineBook[]>([]);
@@ -182,6 +193,22 @@ export const ProfileSettings: React.FC = () => {
           className="w-full rounded border p-2"
         />
       </div>
+      {unlocked.length > 0 && (
+        <div className="pt-4">
+          <h2 className="mb-2 text-sm font-medium">Achievements</h2>
+          <div className="flex gap-2">
+            {unlocked.map((id) => (
+              <span
+                key={id}
+                title={ACHIEVEMENT_LABELS[id]}
+                className="text-primary-600 text-lg"
+              >
+                {iconMap[id]}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="pt-4">
         <h2 className="mb-2 text-sm font-medium">Offline content</h2>
         <div className="mb-2">

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { reportFinishedCount } from './achievements';
 
 export type BookStatus = 'want' | 'reading' | 'finished';
 
@@ -70,6 +71,7 @@ export const useReadingStore = create<ReadingState>()(
           const finishedCount = books.filter(
             (b) => b.status === 'finished',
           ).length;
+          reportFinishedCount(finishedCount);
           return { books, finishedCount };
         }),
       updateProgress: (id, percent) =>
@@ -87,6 +89,7 @@ export const useReadingStore = create<ReadingState>()(
           const finishedCount = books.filter(
             (b) => b.status === 'finished',
           ).length;
+          reportFinishedCount(finishedCount);
           return { books, finishedCount };
         }),
       setYearlyGoal: (goal) => set({ yearlyGoal: goal }),
@@ -105,6 +108,7 @@ export const useReadingStore = create<ReadingState>()(
           const finishedCount = books.filter(
             (b) => b.status === 'finished',
           ).length;
+          reportFinishedCount(finishedCount);
           return { books, finishedCount };
         }),
     }),


### PR DESCRIPTION
## Summary
- track user achievements in a new `useAchievements` store
- unlock badges when publishing or finishing books
- show earned badges in Library and Profile settings

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68856504fa4483319d62a3e9e2bdd5d0