### PR TITLE
Improve accessibility for navigation and modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <title>Bookstr</title>
   </head>
   <body>
+    <a
+      href="#main"
+      class="sr-only focus:not-sr-only absolute top-0 left-0 m-2 rounded bg-primary-600 p-2 text-white z-50"
+    >
+      Skip to main content
+    </a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -34,7 +34,8 @@ export const BottomNav: React.FC<BottomNavProps> = ({
         key={key}
         onClick={() => onChange(key)}
         aria-pressed={active === key}
-        className="flex flex-col items-center py-2 text-sm"
+        aria-label={label}
+        className="flex flex-col items-center py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
       >
         <Icon className="text-xl" aria-hidden="true" />
         <span>{label}</span>

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -82,11 +82,13 @@ export const DMModal: React.FC<DMModalProps> = ({ to, onClose }) => {
           <input
             value={text}
             onChange={(e) => setText(e.target.value)}
-            className="flex-1 rounded border p-2"
+            className="flex-1 rounded border p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
             placeholder="Message"
+            aria-label="Message"
           />
           <button
             onClick={handleSend}
+            aria-label="Send message"
             className="rounded bg-primary-600 px-3 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
           >
             Send

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,7 +79,7 @@ const AppRoutes: React.FC = () => {
           💬
         </button>
       </Header>
-      <main className="p-4">
+      <main id="main" className="p-4">
         <Routes>
           <Route path="/discover" element={<Discover />} />
           <Route path="/library" element={<Library />} />


### PR DESCRIPTION
## Summary
- add skip link for keyboard users
- expose `main` landmark for skip link
- ensure navigation buttons have labels and focus outlines
- improve DM modal accessibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688567f71c3883319e286dbaeb84af02