### PR TITLE
Improve modal responsiveness

### DIFF
--- a/src/components/ChapterEditorModal.tsx
+++ b/src/components/ChapterEditorModal.tsx
@@ -84,8 +84,8 @@ export const ChapterEditorModal: React.FC<Props> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="space-y-2 rounded bg-[color:var(--clr-surface)] p-4 w-full max-w-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-2 sm:p-4">
+      <div className="space-y-2 w-full max-w-sm max-h-screen overflow-y-auto rounded bg-[color:var(--clr-surface)] p-4">
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -54,8 +54,8 @@ export const DMModal: React.FC<DMModalProps> = ({ to, onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="flex h-full w-full flex-col bg-[color:var(--clr-surface)] sm:m-4 sm:max-w-[360px] sm:rounded-md">
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-2 sm:p-4">
+      <div className="flex w-full max-h-screen flex-col bg-[color:var(--clr-surface)] sm:max-w-[360px] sm:rounded-md">
         <div className="flex items-center justify-between border-b p-2">
           <h2 className="text-lg font-medium">Chat</h2>
           {onClose && (


### PR DESCRIPTION
## Summary
- handle content overflow in DMModal and ChapterEditorModal
- allow modals to scroll on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688568dddfa483318daa964c02bf7a53