### PR TITLE
Add empty comments placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -45,6 +45,9 @@ export const Comments: React.FC<CommentsProps> = ({
 
   return (
     <div className={`${parentEventId ? 'ml-4' : ''} space-y-2`}>
+      {replies.length === 0 && !parentEventId && (
+        <p className="text-gray-500">No comments yet – be the first to reply!</p>
+      )}
       {replies.map((c) => (
         <div key={c.id} className="space-y-2">
           <div className="rounded border p-2 flex items-start gap-2">

--- a/test/commentsPlaceholder.test.js
+++ b/test/commentsPlaceholder.test.js
@@ -1,0 +1,50 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/Comments.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: ['react', './src/nostr.tsx'],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({ subscribe: () => () => {}, publishComment: async () => {}, pubkey: '1' }) };
+      }
+      if (p.endsWith('DeleteButton') || p.endsWith('DeleteButton.tsx')) {
+        return { DeleteButton: () => React.createElement('div') };
+      }
+      if (p.endsWith('ReportButton') || p.endsWith('ReportButton.tsx')) {
+        return { ReportButton: () => React.createElement('div') };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'Comments.js' });
+  const { Comments } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(Comments, { bookId: 'book1', events: [] }));
+    await Promise.resolve();
+  });
+
+  const json = renderer.toJSON();
+  const text = JSON.stringify(json);
+  assert.ok(text.includes('No comments yet – be the first to reply!'), 'Placeholder text should be present');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- show placeholder text when a book has no comments
- test comments component placeholder
- run new test as part of npm test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856ef341448331928fe7494a271d82