### PR TITLE
Add no-results message to Discover search

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -120,6 +120,7 @@ export const Discover: React.FC = () => {
     .slice(0, 6);
 
   const recommended = filtered.slice(0, 6);
+  const noResults = search.trim() !== '' && recommended.length === 0;
 
   return (
     <div className="pb-4">
@@ -196,19 +197,23 @@ export const Discover: React.FC = () => {
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Recommended for You</h2>
         <div className="grid grid-cols-2 gap-4">
-          {recommended.length === 0
-            ? Array.from({ length: 6 }).map((_, i) => (
-                <BookCardSkeleton key={i} />
-              ))
-            : recommended.map((e) => (
-                <BookCard
-                  key={e.id}
-                  event={e as NostrEvent}
-                  onDelete={(id) =>
-                    setEvents((evts) => evts.filter((x) => x.id !== id))
-                  }
-                />
-              ))}
+          {noResults ? (
+            <p className="col-span-full text-center">No matching books found.</p>
+          ) : recommended.length === 0 ? (
+            Array.from({ length: 6 }).map((_, i) => (
+              <BookCardSkeleton key={i} />
+            ))
+          ) : (
+            recommended.map((e) => (
+              <BookCard
+                key={e.id}
+                event={e as NostrEvent}
+                onDelete={(id) =>
+                  setEvents((evts) => evts.filter((x) => x.id !== id))
+                }
+              />
+            ))
+          )}
         </div>
       </section>
       <section className="p-4">

--- a/test/discoverSearchNoMatch.test.js
+++ b/test/discoverSearchNoMatch.test.js
@@ -1,0 +1,75 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const { MemoryRouter } = require('react-router-dom');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/Discover.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-router-dom',
+      './src/nostr.tsx',
+      './src/components/BookCard.tsx',
+      './src/components/BookCardSkeleton.tsx',
+      './src/components/OnboardingTooltip.tsx',
+      './src/analytics.ts',
+      './src/components/CommunityFeed.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [] }) };
+      }
+      if (p.endsWith('BookCard') || p.endsWith('BookCard.tsx')) {
+        return { BookCard: () => React.createElement('div') };
+      }
+      if (p.endsWith('BookCardSkeleton') || p.endsWith('BookCardSkeleton.tsx')) {
+        return { BookCardSkeleton: () => React.createElement('div') };
+      }
+      if (p.endsWith('OnboardingTooltip') || p.endsWith('OnboardingTooltip.tsx')) {
+        return { OnboardingTooltip: ({ children }) => React.createElement('div', null, children) };
+      }
+      if (p.endsWith('CommunityFeed') || p.endsWith('CommunityFeed.tsx')) {
+        return { CommunityFeed: () => React.createElement('div') };
+      }
+      if (p.endsWith('analytics') || p.endsWith('analytics.ts')) {
+        return { logEvent: () => {} };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'Discover.js' });
+  const { Discover } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ['/discover?q=nomatch'] },
+        React.createElement(Discover)
+      )
+    );
+    await Promise.resolve();
+  });
+
+  const json = renderer.toJSON();
+  const text = JSON.stringify(json);
+  assert.ok(text.includes('No matching books found.'), 'Search notice should be present');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- show a notice when searching in Discover returns no books
- cover the new behaviour with a node-based test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68856fd9c11c8331913f7ba57a3d5d25