### PR TITLE
Add toast provider and error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
 import { useNostr, publishLongPost } from '../nostr';
+import { useToast } from './ToastProvider';
 import DOMPurify from 'dompurify';
 import { reportBookPublished } from '../achievements';
 
@@ -27,30 +28,36 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
   const next = () => setStep((s) => Math.min(4, s + 1));
   const back = () => setStep((s) => Math.max(0, s - 1));
 
+  const toast = useToast();
+
   const handlePublish = async () => {
-    const evt = await publishLongPost(
-      ctx,
-      {
-        title,
-        summary,
-        content,
-        cover: cover || undefined,
-        tags: tags
-          .split(',')
-          .map((t) => t.trim())
-          .filter(Boolean),
-      },
-      pow ? 20 : 0,
-    );
-    setStep(0);
-    setTitle('');
-    setSummary('');
-    setCover('');
-    setTags('');
-    setContent('');
-    setPow(false);
-    reportBookPublished();
-    if (onPublish) onPublish(evt.id);
+    try {
+      const evt = await publishLongPost(
+        ctx,
+        {
+          title,
+          summary,
+          content,
+          cover: cover || undefined,
+          tags: tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean),
+        },
+        pow ? 20 : 0,
+      );
+      setStep(0);
+      setTitle('');
+      setSummary('');
+      setCover('');
+      setTags('');
+      setContent('');
+      setPow(false);
+      reportBookPublished();
+      if (onPublish) onPublish(evt.id);
+    } catch {
+      toast('Failed to publish book.');
+    }
   };
 
   return (

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+  visible: boolean;
+}
+
+interface ToastContextValue {
+  addToast: (msg: string) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = React.useState<Toast[]>([]);
+
+  const addToast = React.useCallback((message: string) => {
+    const id = Date.now() + Math.random();
+    setToasts((ts) => [...ts, { id, message, visible: true }]);
+    setTimeout(() => {
+      setToasts((ts) => ts.map((t) => (t.id === id ? { ...t, visible: false } : t)));
+    }, 2500);
+    setTimeout(() => {
+      setToasts((ts) => ts.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <div className="fixed bottom-4 left-4 space-y-2 pointer-events-none">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`rounded bg-gray-800 text-white px-4 py-2 transition-opacity duration-500 ${t.visible ? 'opacity-90' : 'opacity-0'}`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export function useToast() {
+  const ctx = React.useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx.addToast;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import { Library } from './components/Library';
 import { BookPublishWizard } from './components/BookPublishWizard';
 import { NotificationFeed } from './components/NotificationFeed';
 import { ProfileSettings } from './components/ProfileSettings';
+import { ToastProvider } from './components/ToastProvider';
 
 const AppRoutes: React.FC = () => {
   const navigate = useNavigate();
@@ -100,9 +101,11 @@ const AppRoutes: React.FC = () => {
 };
 
 export const App: React.FC = () => (
-  <ThemeProvider>
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
-  </ThemeProvider>
+  <ToastProvider>
+    <ThemeProvider>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </ThemeProvider>
+  </ToastProvider>
 );

--- a/test/bookPublishToast.test.js
+++ b/test/bookPublishToast.test.js
@@ -1,0 +1,78 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/BookPublishWizard.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'dompurify',
+      'marked',
+      './src/nostr.tsx',
+      './src/achievements.ts',
+      './src/components/ToastProvider.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const calls = [];
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({}), publishLongPost: async () => { throw new Error('fail'); } };
+      }
+      if (p === './src/achievements.ts') {
+        return { reportBookPublished: () => {} };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => (msg) => calls.push(msg) };
+      }
+      if (p === 'dompurify') {
+        return { __esModule: true, default: { sanitize: (v) => v } };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'BookPublishWizard.js' });
+  const { BookPublishWizard } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(BookPublishWizard));
+    await Promise.resolve();
+  });
+
+  // advance to publish step
+  for (let i = 0; i < 4; i++) {
+    await TestRenderer.act(async () => {
+      const btn = renderer.root.findAll(
+        (n) => n.type === 'button' && n.children.includes('Next'),
+      )[0];
+      btn.props.onClick();
+      await Promise.resolve();
+    });
+  }
+
+  await TestRenderer.act(async () => {
+    const publishBtn = renderer.root.findAll(
+      (n) => n.type === 'button' && n.children.includes('Publish'),
+    )[0];
+    await publishBtn.props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.ok(calls.includes('Failed to publish book.'), 'addToast should be called');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- create `ToastProvider` with `useToast`
- use `ToastProvider` at app root
- show toast when book publish fails
- add test verifying toast on publish error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885718534d48331ba9ccfb1c13a076b