### PR TITLE
Show toast on publish errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FaTrash } from 'react-icons/fa';
 import { useNostr } from '../nostr';
+import { useToast } from './ToastProvider';
 
 export interface DeleteButtonProps {
   target: string;
@@ -14,13 +15,14 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
   className,
 }) => {
   const { publish } = useNostr();
+  const toast = useToast();
 
   const handleClick = async () => {
     try {
       await publish({ kind: 5, content: '', tags: [['e', target]] });
       onDelete?.();
     } catch {
-      // ignore publish errors
+      toast('Action failed', { type: 'error' });
     }
   };
 

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { FaThumbsUp, FaStar } from 'react-icons/fa';
 import { useNostr, publishVote, publishFavourite } from '../nostr';
+import { useToast } from './ToastProvider';
 import type { Event as NostrEvent } from 'nostr-tools';
 
 export interface ReactionButtonProps {
@@ -15,6 +16,7 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
   className,
 }) => {
   const ctx = useNostr();
+  const toast = useToast();
   const [count, setCount] = useState(0);
   const ids = useRef(new Set<string>());
   const [active, setActive] = useState(false);
@@ -44,7 +46,7 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
       }
       setActive(true);
     } catch {
-      /* ignore publish errors */
+      toast('Action failed', { type: 'error' });
     }
   };
 

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FaRetweet } from 'react-icons/fa';
 import { useNostr, publishRepost } from '../nostr';
+import { useToast } from './ToastProvider';
 
 export interface RepostButtonProps {
   target: string;
@@ -12,12 +13,13 @@ export const RepostButton: React.FC<RepostButtonProps> = ({
   className,
 }) => {
   const ctx = useNostr();
+  const toast = useToast();
 
   const handleClick = async () => {
     try {
       await publishRepost(ctx, target);
     } catch {
-      // ignore publish errors
+      toast('Action failed', { type: 'error' });
     }
   };
 

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -4,10 +4,11 @@ interface Toast {
   id: number;
   message: string;
   visible: boolean;
+  type: 'success' | 'error';
 }
 
 interface ToastContextValue {
-  addToast: (msg: string) => void;
+  addToast: (msg: string, opts?: { type?: 'success' | 'error' }) => void;
 }
 
 const ToastContext = React.createContext<ToastContextValue | undefined>(undefined);
@@ -15,9 +16,10 @@ const ToastContext = React.createContext<ToastContextValue | undefined>(undefine
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [toasts, setToasts] = React.useState<Toast[]>([]);
 
-  const addToast = React.useCallback((message: string) => {
+  const addToast = React.useCallback((message: string, opts?: { type?: 'success' | 'error' }) => {
     const id = Date.now() + Math.random();
-    setToasts((ts) => [...ts, { id, message, visible: true }]);
+    const type = opts?.type ?? 'success';
+    setToasts((ts) => [...ts, { id, message, visible: true, type }]);
     setTimeout(() => {
       setToasts((ts) => ts.map((t) => (t.id === id ? { ...t, visible: false } : t)));
     }, 2500);
@@ -33,7 +35,9 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         {toasts.map((t) => (
           <div
             key={t.id}
-            className={`rounded bg-gray-800 text-white px-4 py-2 transition-opacity duration-500 ${t.visible ? 'opacity-90' : 'opacity-0'}`}
+            className={`rounded px-4 py-2 transition-opacity duration-500 ${
+              t.type === 'error' ? 'bg-red-600 text-white' : 'bg-gray-800 text-white'
+            } ${t.visible ? 'opacity-90' : 'opacity-0'}`}
           >
             {t.message}
           </div>

--- a/test/deleteButtonToast.test.js
+++ b/test/deleteButtonToast.test.js
@@ -1,0 +1,59 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/DeleteButton.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-icons/fa',
+      './src/nostr.tsx',
+      './src/components/ToastProvider.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const calls = [];
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({ publish: async () => { throw new Error('fail'); } }) };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => (msg) => calls.push(msg) };
+      }
+      if (p === 'react-icons/fa') {
+        return { FaTrash: () => React.createElement('div') };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'DeleteButton.js' });
+  const { DeleteButton } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(DeleteButton, { target: '1' }));
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    renderer.root.findByType('button').props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.ok(calls.includes('Action failed'), 'addToast should be called');
+  console.log('All tests passed.');
+})();

--- a/test/reactionButtonToast.test.js
+++ b/test/reactionButtonToast.test.js
@@ -1,0 +1,64 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/ReactionButton.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-icons/fa',
+      './src/nostr.tsx',
+      './src/components/ToastProvider.tsx',
+      'nostr-tools',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const calls = [];
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({ subscribe: () => () => {}, pubkey: '1' }),
+          publishVote: async () => { throw new Error('fail'); },
+          publishFavourite: async () => { throw new Error('fail'); },
+        };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => (msg) => calls.push(msg) };
+      }
+      if (p === 'react-icons/fa') {
+        return { FaThumbsUp: () => React.createElement('div'), FaStar: () => React.createElement('div') };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'ReactionButton.js' });
+  const { ReactionButton } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(ReactionButton, { target: '1', type: 'vote' }));
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    renderer.root.findByType('button').props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.ok(calls.includes('Action failed'), 'addToast should be called');
+  console.log('All tests passed.');
+})();

--- a/test/repostButtonToast.test.js
+++ b/test/repostButtonToast.test.js
@@ -1,0 +1,62 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/RepostButton.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-icons/fa',
+      './src/nostr.tsx',
+      './src/components/ToastProvider.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const calls = [];
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({}),
+          publishRepost: async () => { throw new Error('fail'); },
+        };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => (msg) => calls.push(msg) };
+      }
+      if (p === 'react-icons/fa') {
+        return { FaRetweet: () => React.createElement('div') };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'RepostButton.js' });
+  const { RepostButton } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(RepostButton, { target: '1' }));
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    renderer.root.findByType('button').props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.ok(calls.includes('Action failed'), 'addToast should be called');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- improve toast provider styling and API
- surface errors in reaction, repost, and delete buttons
- add tests for toast calls on publish failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885734ba9ac833184c8d9a0a5acac9e