### PR TITLE
Extend settings persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ specification but functionality is limited.
 - **Service worker** – `src/sw.ts` provides offline caching and background sync
   for a Progressive Web App.
 
+## Settings
+
+Open the profile settings from the library screen to configure the app:
+
+- **Theme** – pick one of the preset palettes via the theme selector.
+- **Yearly reading goal** – store your annual goal which updates progress in the library view.
+- **Clear Cached Books** – remove any books saved for offline reading.
+
+
 ## Getting Started
 
 1. Install dependencies

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSettings } from './useSettings';
 
 export type Theme = 'default' | 'dark' | 'earthy' | 'vibrant' | 'pastel';
 
@@ -14,14 +15,11 @@ const ThemeContext = React.createContext<ThemeContextValue | undefined>(
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [theme, setTheme] = React.useState<Theme>(() => {
-    const stored = localStorage.getItem('theme') as Theme | null;
-    return stored ?? 'default';
-  });
+  const theme = useSettings((s) => s.theme);
+  const setTheme = useSettings((s) => s.setTheme);
 
   React.useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
   }, [theme]);
 
   return (

--- a/src/useSettings.ts
+++ b/src/useSettings.ts
@@ -8,15 +8,17 @@ export interface SettingsState {
   density: Density;
   offlineMaxBooks: number;
   pushEnabled: boolean;
+  theme: import('./ThemeProvider').Theme;
   setTextSize: (size: number) => void;
   setDensity: (d: Density) => void;
   setOfflineMaxBooks: (n: number) => void;
   setPushEnabled: (v: boolean) => void;
+  setTheme: (t: import('./ThemeProvider').Theme) => void;
   hydrate: (
     data: Partial<
       Pick<
         SettingsState,
-        'textSize' | 'density' | 'offlineMaxBooks' | 'pushEnabled'
+        'textSize' | 'density' | 'offlineMaxBooks' | 'pushEnabled' | 'theme'
       >
     >,
   ) => void;
@@ -29,10 +31,12 @@ export const useSettings = create<SettingsState>()(
       density: 'comfortable',
       offlineMaxBooks: 3,
       pushEnabled: false,
+      theme: 'default',
       setTextSize: (textSize) => set({ textSize }),
       setDensity: (density) => set({ density }),
       setOfflineMaxBooks: (offlineMaxBooks) => set({ offlineMaxBooks }),
       setPushEnabled: (pushEnabled) => set({ pushEnabled }),
+      setTheme: (theme) => set({ theme }),
       hydrate: (data) => set(data),
     }),
     { name: 'settings-store' },


### PR DESCRIPTION
## Summary
- persist selected theme via `useSettings`
- document settings options in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885788a898c8331839c2ac4048b2b68