### PR TITLE
Add publishing wizard tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Open the profile settings from the library screen to configure the app:
 4. If no NIP‑07 wallet is detected, you can still log in by pasting your
    private key into the login screen to sign events manually.
 
+For a step-by-step guide on using the book publishing wizard, see
+[docs/first_publish.md](docs/first_publish.md).
+
 The build setup is now complete and consists of the following steps:
 
 1. Run `npm test` to execute the unit tests.

--- a/docs/first_publish.md
+++ b/docs/first_publish.md
@@ -1,0 +1,22 @@
+# Publishing Your First Book
+
+This guide walks you through using the `BookPublishWizard` to create and publish a book event on Nostr.
+
+## 1. Starting the Wizard
+
+Open the "Write" screen or choose **Publish Book** from the library. The wizard appears and guides you through several steps.
+
+## 2. Enter Details
+
+1. **Title & Summary** – Fill in the title and a short summary then press **Next**.
+2. **Cover Image** – Paste a URL for the cover artwork (optional). Continue with **Next**.
+3. **Tags** – Enter comma separated tags and press **Next**.
+4. **Content** – Write the book using Markdown. Press **Next** once more to preview.
+
+## 3. Proof‑of‑Work and Publishing
+
+On the final screen you can review the preview. Tick **Enable proof-of-work** if desired to add a small PoW to the event before clicking **Publish**. Successful publishing calls `reportBookPublished()` and unlocks the *First Book Published* achievement.
+
+## 4. Locating the Event
+
+After publishing, the wizard returns to the first step. You can find your new `kind:30023` event by querying your configured relays. Most clients will show it in your profile or search results a few seconds after publication.


### PR DESCRIPTION
## Summary
- document publishing flow in `docs/first_publish.md`
- link the tutorial from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857a0af3488331839642730567f095