### PR TITLE
Add zap documentation and tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Open the profile settings from the library screen to configure the app:
 
 For a step-by-step guide on using the book publishing wizard, see
 [docs/first_publish.md](docs/first_publish.md).
+To learn more about sending lightning zaps, read
+[docs/zapping.md](docs/zapping.md).
 
 The build setup is now complete and consists of the following steps:
 

--- a/docs/zapping.md
+++ b/docs/zapping.md
@@ -1,0 +1,19 @@
+# Sending a Zap
+
+This short guide explains how to send a lightning "zap" to tip another user.
+
+## Requirements
+
+- The target profile must include a lightning address.
+- A WebLN compatible wallet can be used to pay automatically (optional).
+
+## Zapping a Book
+
+1. Click **Zap** on a `BookCard`.
+2. Bookstr queries the profile's lightning address and creates a zap request event.
+3. The lnurl callback returns an invoice which can be paid via WebLN or any lightning wallet.
+
+## Confirmation
+
+After payment Bookstr waits for the `9735` zap receipt event that matches the invoice. Once received the zap is confirmed and the button updates to *Zapped!*.
+

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -7,6 +7,7 @@ import { ReportButton } from './ReportButton';
 import { FaHeart } from 'react-icons/fa';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { logEvent } from '../analytics';
+import { OnboardingTooltip } from './OnboardingTooltip';
 
 interface BookCardProps {
   event: NostrEvent & { repostedBy?: string };
@@ -80,16 +81,21 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         </a>
       ))}
       <div className="pt-2 flex gap-2">
-        <button
-          onClick={handleZap}
-          className="rounded bg-yellow-500 px-2 py-1 text-white"
+        <OnboardingTooltip
+          storageKey="zap-button"
+          text="Send a lightning zap tip"
         >
-          {status === 'zapping'
-            ? 'Zapping...'
-            : status === 'done'
-              ? 'Zapped!'
-              : 'Zap'}
-        </button>
+          <button
+            onClick={handleZap}
+            className="rounded bg-yellow-500 px-2 py-1 text-white"
+          >
+            {status === 'zapping'
+              ? 'Zapping...'
+              : status === 'done'
+                ? 'Zapped!'
+                : 'Zap'}
+          </button>
+        </OnboardingTooltip>
         <ReactionButton target={event.id} type="vote" />
         <RepostButton target={event.id} />
         <ReportButton target={event.id} />


### PR DESCRIPTION
## Summary
- add documentation on sending zaps
- link zap guide from README
- show onboarding tooltip around the Zap button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68857ae51dc48331837ec5936241e87d