### PR TITLE
Add DOMPurify allowlist and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Open the profile settings from the library screen to configure the app:
 - **Yearly reading goal** – store your annual goal which updates progress in the library view.
 - **Clear Cached Books** – remove any books saved for offline reading.
 
-
 ## Getting Started
 
 1. Install dependencies
@@ -41,7 +40,7 @@ Open the profile settings from the library screen to configure the app:
    ```bash
    npx vite
    ```
- The entry point is `src/main.tsx`.
+   The entry point is `src/main.tsx`.
 3. Build the PWA for production. With Vite the build command is:
    ```bash
    npx vite build
@@ -56,6 +55,8 @@ For a step-by-step guide on using the book publishing wizard, see
 [docs/first_publish.md](docs/first_publish.md).
 To learn more about sending lightning zaps, read
 [docs/zapping.md](docs/zapping.md).
+For details on the HTML permitted in Markdown, see
+[docs/allowed_html.md](docs/allowed_html.md).
 
 ## Nostr Features
 

--- a/docs/allowed_html.md
+++ b/docs/allowed_html.md
@@ -1,0 +1,38 @@
+# Allowed HTML Tags
+
+Bookstr sanitizes all user supplied Markdown with DOMPurify. Only a minimal set of HTML elements is permitted to keep books lightweight.
+
+## Tags
+
+- a
+- b
+- i
+- em
+- strong
+- p
+- ul
+- ol
+- li
+- pre
+- code
+- blockquote
+- h1
+- h2
+- h3
+- h4
+- h5
+- h6
+- img
+- hr
+- br
+
+## Attributes
+
+- href
+- src
+- alt
+- title
+- rel
+- target
+
+Any other tags or attributes will be stripped during sanitisation.

--- a/docs/first_publish.md
+++ b/docs/first_publish.md
@@ -11,11 +11,11 @@ Open the "Write" screen or choose **Publish Book** from the library. The wizard 
 1. **Title & Summary** – Fill in the title and a short summary then press **Next**.
 2. **Cover Image** – Paste a URL for the cover artwork (optional). Continue with **Next**.
 3. **Tags** – Enter comma separated tags and press **Next**.
-4. **Content** – Write the book using Markdown. Press **Next** once more to preview.
+4. **Content** – Write the book using Markdown. Only a small set of HTML tags is allowed. See [allowed_html.md](allowed_html.md) for details. Press **Next** once more to preview.
 
 ## 3. Proof‑of‑Work and Publishing
 
-On the final screen you can review the preview. Tick **Enable proof-of-work** if desired to add a small PoW to the event before clicking **Publish**. Successful publishing calls `reportBookPublished()` and unlocks the *First Book Published* achievement.
+On the final screen you can review the preview. Tick **Enable proof-of-work** if desired to add a small PoW to the event before clicking **Publish**. Successful publishing calls `reportBookPublished()` and unlocks the _First Book Published_ achievement.
 
 ## 4. Locating the Event
 

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
 import { useNostr, publishLongPost } from '../nostr';
 import { useToast } from './ToastProvider';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';
 
 export interface BookPublishWizardProps {
@@ -21,7 +21,7 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
   const [content, setContent] = useState('');
   const [pow, setPow] = useState(false);
   const previewHtml = useMemo(
-    () => DOMPurify.sanitize(marked.parse(content)),
+    () => sanitizeHtml(marked.parse(content)),
     [content],
   );
 

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { cacheBookHtml, getCachedBookHtml } from '../htmlCache';
 import { saveOfflineBook } from '../offlineStore';
 import { logEvent } from '../analytics';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '../sanitizeHtml';
 
 export interface ReaderViewProps {
   bookId: string;
@@ -35,7 +35,7 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [content, setContent] = useState(html);
-  const sanitizedContent = useMemo(() => DOMPurify.sanitize(content), [content]);
+  const sanitizedContent = useMemo(() => sanitizeHtml(content), [content]);
 
   useEffect(() => {
     setContent(html);

--- a/src/sanitizeHtml.ts
+++ b/src/sanitizeHtml.ts
@@ -1,0 +1,32 @@
+import DOMPurify, { Config } from 'dompurify';
+
+export const SANITIZE_CONFIG: Config = {
+  ALLOWED_TAGS: [
+    'a',
+    'b',
+    'i',
+    'em',
+    'strong',
+    'p',
+    'ul',
+    'ol',
+    'li',
+    'pre',
+    'code',
+    'blockquote',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'img',
+    'hr',
+    'br',
+  ],
+  ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'rel', 'target'],
+};
+
+export function sanitizeHtml(html: string): string {
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG);
+}


### PR DESCRIPTION
## Summary
- centralise DOMPurify config in `sanitizeHtml.ts`
- use the new sanitizer in BookPublishWizard and ReaderView
- document which tags/attributes are allowed
- link to the new docs from README and first publish guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688580fadf2083319cf6556a32a64260