### PR TITLE
Publish book meta as kind 41

### DIFF
--- a/docs/first_publish.md
+++ b/docs/first_publish.md
@@ -19,4 +19,8 @@ On the final screen you can review the preview. Tick **Enable proof-of-work** if
 
 ## 4. Locating the Event
 
-After publishing, the wizard returns to the first step. You can find your new `kind:30023` event by querying your configured relays. Most clients will show it in your profile or search results a few seconds after publication.
+After publishing, the wizard returns to the first step. Two events are sent:
+the long-form `kind:30023` entry and a matching `kind:41` list event that
+references it. This list event ensures your book appears in the library and in
+`BookListScreen`. Most clients will show the events in your profile or search
+results a few seconds after publication.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/validators.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/validators.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
-import { useNostr, publishLongPost } from '../nostr';
+import { useNostr, publishLongPost, publishBookMeta } from '../nostr';
 import { useToast } from './ToastProvider';
 import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';
@@ -38,6 +38,20 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
           title,
           summary,
           content,
+          cover: cover || undefined,
+          tags: tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean),
+        },
+        pow ? 20 : 0,
+      );
+      await publishBookMeta(
+        ctx,
+        evt.id,
+        {
+          title,
+          summary,
           cover: cover || undefined,
           tags: tags
             .split(',')

--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -491,6 +491,20 @@ export async function publishLongPost(
   );
 }
 
+export async function publishBookMeta(
+  ctx: NostrContextValue,
+  bookId: string,
+  meta: { title?: string; summary?: string; cover?: string; tags?: string[] },
+  pow = 0,
+) {
+  const tags: string[][] = [['d', bookId]];
+  if (meta.title) tags.push(['title', meta.title]);
+  if (meta.summary) tags.push(['summary', meta.summary]);
+  if (meta.cover) tags.push(['image', meta.cover]);
+  meta.tags?.forEach((t) => tags.push(['t', t]));
+  return ctx.publish({ kind: 41, content: '', tags }, undefined, pow);
+}
+
 export async function publishVote(ctx: NostrContextValue, target: string) {
   return ctx.publish({ kind: 7, content: '+', tags: [['e', target]] });
 }

--- a/test/bookPublishMeta.test.js
+++ b/test/bookPublishMeta.test.js
@@ -1,0 +1,89 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/BookPublishWizard.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'dompurify',
+      'marked',
+      './src/nostr.tsx',
+      './src/achievements.ts',
+      './src/components/ToastProvider.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  let metaArgs;
+  let onPublishId;
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({}),
+          publishLongPost: async () => ({ id: 'abc123' }),
+          publishBookMeta: async (...args) => {
+            metaArgs = args;
+          },
+        };
+      }
+      if (p === './src/achievements.ts') {
+        return { reportBookPublished: () => {} };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => () => {} };
+      }
+      if (p === 'dompurify') {
+        return { __esModule: true, default: { sanitize: (v) => v } };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'BookPublishWizard.js' });
+  const { BookPublishWizard } = module.exports;
+
+  const onPublish = (id) => {
+    onPublishId = id;
+  };
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(BookPublishWizard, { onPublish }));
+    await Promise.resolve();
+  });
+
+  for (let i = 0; i < 4; i++) {
+    await TestRenderer.act(async () => {
+      const btn = renderer.root.findAll(
+        (n) => n.type === 'button' && n.children.includes('Next'),
+      )[0];
+      btn.props.onClick();
+      await Promise.resolve();
+    });
+  }
+
+  await TestRenderer.act(async () => {
+    const publishBtn = renderer.root.findAll(
+      (n) => n.type === 'button' && n.children.includes('Publish'),
+    )[0];
+    await publishBtn.props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.strictEqual(onPublishId, 'abc123');
+  assert.strictEqual(metaArgs[1], 'abc123');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add `publishBookMeta` helper
- publish meta list events from the wizard
- test that list events are sent
- mention list event in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688583a4ddfc8331ac188f0698843af6