### PR TITLE
Ensure only book authors can edit chapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/validators.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/test/bookDetailAuthorFilter.test.js
+++ b/test/bookDetailAuthorFilter.test.js
@@ -1,0 +1,78 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const { MemoryRouter, Routes, Route } = require('react-router-dom');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/screens/BookDetailScreen.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: ['react', 'react-router-dom', '@hello-pangea/dnd', './src/nostr.tsx'],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const calls = [];
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({
+            subscribe: (filters, cb) => {
+              calls.push(filters);
+              if (filters[0].kinds && filters[0].kinds.includes(30023)) {
+                cb({ id: '1', pubkey: 'author', tags: [], kind: 30023 });
+              }
+              return () => {};
+            },
+            publish: async () => {},
+            pubkey: 'author',
+          }),
+        };
+      }
+      if (p === '@hello-pangea/dnd') {
+        return {
+          DragDropContext: ({ children }) => React.createElement('div', null, children),
+          Droppable: ({ children }) =>
+            React.createElement('div', null, children({ droppableProps: {}, innerRef: () => {}, placeholder: null })),
+          Draggable: ({ children }) =>
+            React.createElement('div', null, children({ draggableProps: {}, dragHandleProps: {}, innerRef: () => {} })),
+        };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'BookDetailScreen.js' });
+  const { BookDetailScreen } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ['/book/1'] },
+        React.createElement(
+          Routes,
+          null,
+          React.createElement(Route, { path: '/book/:bookId', element: React.createElement(BookDetailScreen) })
+        )
+      )
+    );
+    await Promise.resolve();
+  });
+
+  const hasAuthorFilter = calls.some(
+    (f) => f[0].authors && f[0].authors.includes('author')
+  );
+  assert.ok(hasAuthorFilter, 'subscribe should use authors filter');
+  console.log('All tests passed.');
+})();

--- a/test/chapterEditorModalAuth.test.js
+++ b/test/chapterEditorModalAuth.test.js
@@ -1,0 +1,64 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/ChapterEditorModal.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: ['react', './src/nostr.tsx', './src/components/ToastProvider.tsx'],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  let published = false;
+  let toastMsg;
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({
+            publish: async () => { published = true; },
+            subscribe: () => () => {},
+            pubkey: 'user',
+          }),
+        };
+      }
+      if (p === './src/components/ToastProvider.tsx') {
+        return { useToast: () => (msg) => { toastMsg = msg; } };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'ChapterEditorModal.js' });
+  const { ChapterEditorModal } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(ChapterEditorModal, { bookId: '1', chapterNumber: 1, authorPubkey: 'author', onClose: () => {} })
+    );
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    const btn = renderer.root.findAll(
+      (n) => n.type === 'button' && n.children.includes('Save')
+    )[0];
+    await btn.props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.strictEqual(published, false, 'publish should not be called');
+  assert.ok(toastMsg, 'toast should be shown');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- track the author pubkey in `BookDetailScreen`
- gate edit features behind pubkey match
- enforce author ownership in `ChapterEditorModal`
- provide author pubkey to chapter editor
- add tests for author filters and permission checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688585f497548331a4cc5ea40f688045