### PR TITLE
Add book metadata editor

### DIFF
--- a/src/components/BookMetadataEditor.tsx
+++ b/src/components/BookMetadataEditor.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+import { useNostr, publishBookMeta } from '../nostr';
+import { useToast } from './ToastProvider';
+
+export interface BookMetadataEditorProps {
+  bookId: string;
+  authorPubkey: string;
+  meta: { title?: string; summary?: string; cover?: string; tags?: string[] };
+  onClose: () => void;
+}
+
+export const BookMetadataEditor: React.FC<BookMetadataEditorProps> = ({
+  bookId,
+  authorPubkey,
+  meta,
+  onClose,
+}) => {
+  const ctx = useNostr();
+  const toast = useToast();
+  const [title, setTitle] = useState('');
+  const [summary, setSummary] = useState('');
+  const [cover, setCover] = useState('');
+  const [tags, setTags] = useState('');
+
+  useEffect(() => {
+    setTitle(meta.title || '');
+    setSummary(meta.summary || '');
+    setCover(meta.cover || '');
+    setTags(meta.tags?.join(', ') || '');
+  }, [meta]);
+
+  const handleSave = async () => {
+    if (ctx.pubkey !== authorPubkey) {
+      toast('Action failed', { type: 'error' });
+      return;
+    }
+    try {
+      await publishBookMeta(
+        ctx,
+        bookId,
+        {
+          title,
+          summary,
+          cover: cover || undefined,
+          tags: tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean),
+        },
+      );
+      onClose();
+    } catch {
+      toast('Action failed', { type: 'error' });
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-2 sm:p-4">
+      <div className="space-y-2 w-full max-w-sm max-h-screen overflow-y-auto rounded bg-[color:var(--clr-surface)] p-4">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          className="w-full rounded border p-2"
+        />
+        <textarea
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+          placeholder="Summary"
+          className="w-full rounded border p-2"
+        />
+        <input
+          value={cover}
+          onChange={(e) => setCover(e.target.value)}
+          placeholder="Cover"
+          className="w-full rounded border p-2"
+        />
+        <input
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="Tags comma separated"
+          className="w-full rounded border p-2"
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="rounded border px-3 py-1">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="rounded bg-primary-600 px-3 py-1 text-white"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from '@hello-pangea/dnd';
 import { useNostr } from '../nostr';
 import { ChapterEditorModal } from '../components/ChapterEditorModal';
+import { BookMetadataEditor } from '../components/BookMetadataEditor';
 
 interface ChapterEvent {
   id: string;
@@ -23,6 +24,7 @@ export const BookDetailScreen: React.FC = () => {
     title: string;
     summary: string;
     cover?: string;
+    tags: string[];
   } | null>(null);
   const [chapterIds, setChapterIds] = useState<string[]>([]);
   const [chapters, setChapters] = useState<Record<string, ChapterEvent>>({});
@@ -30,6 +32,7 @@ export const BookDetailScreen: React.FC = () => {
     id?: string;
     number: number;
   } | null>(null);
+  const [editMeta, setEditMeta] = useState(false);
   const canEdit = pubkey && authorPubkey && pubkey === authorPubkey;
 
   useEffect(() => {
@@ -52,6 +55,7 @@ export const BookDetailScreen: React.FC = () => {
           title: evt.tags.find((t) => t[0] === 'title')?.[1] ?? 'Untitled',
           summary: evt.tags.find((t) => t[0] === 'summary')?.[1] ?? '',
           cover: evt.tags.find((t) => t[0] === 'image')?.[1],
+          tags: evt.tags.filter((t) => t[0] === 't').map((t) => t[1]),
         });
       },
     );
@@ -112,7 +116,13 @@ export const BookDetailScreen: React.FC = () => {
         </div>
       )}
       {canEdit && (
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => setEditMeta(true)}
+            className="rounded border px-3 py-1"
+          >
+            Edit Book
+          </button>
           <button
             onClick={() =>
               setModalData({ number: chapterIds.length + 1 })
@@ -175,6 +185,14 @@ export const BookDetailScreen: React.FC = () => {
           chapterId={modalData.id}
           authorPubkey={authorPubkey ?? ''}
           onClose={() => setModalData(null)}
+        />
+      )}
+      {editMeta && meta && bookId && (
+        <BookMetadataEditor
+          bookId={bookId}
+          authorPubkey={authorPubkey ?? ''}
+          meta={meta}
+          onClose={() => setEditMeta(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- implement `BookMetadataEditor` modal for editing title, summary, cover and tags
- update `BookDetailScreen` to use new modal
- allow authors to edit book metadata via `publishBookMeta`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885924945c08331832b2c041a021347