### PR TITLE
Handle fallback library versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/server/index.js
+++ b/server/index.js
@@ -4,16 +4,45 @@ const { SimplePool } = require('nostr-tools');
 const { relays, prunePolicy } = require('./config');
 const app = express();
 const pool = new SimplePool();
+const fallbackVersions = {};
 
 const PORT = process.env.PORT || 3000;
 const API_BASE = process.env.API_BASE || '/api';
 
 app.use(express.json());
 
-app.post(`${API_BASE}/action`, (req, res) => {
+async function actionHandler(req, res) {
   console.log('action', req.body);
-  res.json({ status: 'ok' });
-});
+  const event = req.body;
+
+  const activeRelays = relays.filter(
+    (r) => r.retentionDays >= prunePolicy.minimumDays,
+  );
+  const targets = activeRelays
+    .filter((r) => r.supportsNip27)
+    .map((r) => r.url);
+
+  let fallbackVersion;
+  if (activeRelays.some((r) => !r.supportsNip27) && Array.isArray(event.tags)) {
+    const dTag = event.tags.find((t) => t[0] === 'd');
+    if (dTag) {
+      const base = dTag[1];
+      fallbackVersions[base] = (fallbackVersions[base] || 0) + 1;
+      fallbackVersion = fallbackVersions[base];
+      dTag[1] = `${base}-v${fallbackVersion}`;
+    }
+  }
+
+  try {
+    await pool.publish(targets, event);
+    res.json({ status: 'ok', fallbackVersion });
+  } catch (err) {
+    console.error('publish failed', err);
+    res.status(500).json({ error: 'publish failed' });
+  }
+}
+
+app.post(`${API_BASE}/action`, actionHandler);
 
 app.post(`${API_BASE}/event`, async (req, res) => {
   console.log('event', req.body);
@@ -46,6 +75,10 @@ app.get('*', (_, res) => {
   res.sendFile(path.join(distPath, 'index.html'));
 });
 
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = { app, actionHandler, fallbackVersions, pool };

--- a/server/index.js
+++ b/server/index.js
@@ -23,7 +23,7 @@ async function actionHandler(req, res) {
     .map((r) => r.url);
 
   let fallbackVersion;
-  if (activeRelays.some((r) => !r.supportsNip27) && Array.isArray(event.tags)) {
+  if (relays.some((r) => !r.supportsNip27) && Array.isArray(event.tags)) {
     const dTag = event.tags.find((t) => t[0] === 'd');
     if (dTag) {
       const base = dTag[1];

--- a/test/api_action.test.js
+++ b/test/api_action.test.js
@@ -1,0 +1,30 @@
+require('ts-node/register');
+const assert = require('assert');
+const { actionHandler, fallbackVersions, pool } = require('../server');
+
+(async () => {
+  let published;
+  pool.publish = async (_targets, evt) => {
+    published = JSON.parse(JSON.stringify(evt));
+  };
+
+  const res = { json: () => {}, status: () => res, body: null };
+
+  const baseEvent = { kind: 30001, content: '', tags: [['d', 'library']] };
+
+  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)) }, res);
+  assert.strictEqual(fallbackVersions['library'], 1);
+  assert.strictEqual(
+    published.tags.find((t) => t[0] === 'd')[1],
+    'library-v1',
+  );
+
+  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)) }, res);
+  assert.strictEqual(fallbackVersions['library'], 2);
+  assert.strictEqual(
+    published.tags.find((t) => t[0] === 'd')[1],
+    'library-v2',
+  );
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- increment fallback version when a configured relay lacks NIP‑27 support
- update `/api/action` to append this version to the `d` tag before publishing
- export `actionHandler` and in-memory version map for tests
- add tests verifying fallback counter and tag changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688596a0bf4c83318ffd23742d02c31c