### PR TITLE
Add signature verification for server events

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js && node test/server_signature.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/test/api_action.test.js
+++ b/test/api_action.test.js
@@ -1,6 +1,7 @@
 require('ts-node/register');
 const assert = require('assert');
 const { actionHandler, fallbackVersions, pool } = require('../server');
+const { finalizeEvent, generateSecretKey } = require('nostr-tools');
 
 (async () => {
   let published;
@@ -10,16 +11,22 @@ const { actionHandler, fallbackVersions, pool } = require('../server');
 
   const res = { json: () => {}, status: () => res, body: null };
 
-  const baseEvent = { kind: 30001, content: '', tags: [['d', 'library']] };
+  const sk = generateSecretKey();
+  const baseEvent = finalizeEvent({
+    kind: 30001,
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [['d', 'library']],
+  }, sk);
 
-  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)) }, res);
+  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)), user: { pubkey: baseEvent.pubkey } }, res);
   assert.strictEqual(fallbackVersions['library'], 1);
   assert.strictEqual(
     published.tags.find((t) => t[0] === 'd')[1],
     'library-v1',
   );
 
-  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)) }, res);
+  await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)), user: { pubkey: baseEvent.pubkey } }, res);
   assert.strictEqual(fallbackVersions['library'], 2);
   assert.strictEqual(
     published.tags.find((t) => t[0] === 'd')[1],

--- a/test/server_signature.test.js
+++ b/test/server_signature.test.js
@@ -29,7 +29,7 @@ const { finalizeEvent, generateSecretKey } = require('nostr-tools');
 
   const badSig = { ...validEvent, sig: '0'.repeat(128) };
   res.statusCode = undefined; res.body = null; published = null;
-  await eventHandler({ body: badSig, user: { pubkey: validEvent.pubkey } }, res);
+  await eventHandler({ body: JSON.parse(JSON.stringify(badSig)), user: { pubkey: validEvent.pubkey } }, res);
   assert.strictEqual(res.statusCode, 400);
   assert.ok(res.body.error);
 

--- a/test/server_signature.test.js
+++ b/test/server_signature.test.js
@@ -1,0 +1,37 @@
+require('ts-node/register');
+const assert = require('assert');
+const { eventHandler, pool } = require('../server');
+const { finalizeEvent, generateSecretKey } = require('nostr-tools');
+
+(async () => {
+  let published;
+  pool.publish = async (_targets, evt) => { published = evt; };
+
+  const sk = generateSecretKey();
+  const validEvent = finalizeEvent({
+    kind: 41,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [],
+    content: '',
+  }, sk);
+
+  const res = { status(code) { this.statusCode = code; return this; }, json(obj) { this.body = obj; } };
+
+  await eventHandler({ body: JSON.parse(JSON.stringify(validEvent)), user: { pubkey: validEvent.pubkey } }, res);
+  assert.strictEqual(res.statusCode, undefined);
+  assert.strictEqual(res.body.status, 'ok');
+  assert.strictEqual(published.id, validEvent.id);
+
+  res.statusCode = undefined; res.body = null; published = null;
+  await eventHandler({ body: JSON.parse(JSON.stringify(validEvent)), user: { pubkey: 'bad' } }, res);
+  assert.strictEqual(res.statusCode, 400);
+  assert.ok(res.body.error);
+
+  const badSig = { ...validEvent, sig: '0'.repeat(128) };
+  res.statusCode = undefined; res.body = null; published = null;
+  await eventHandler({ body: badSig, user: { pubkey: validEvent.pubkey } }, res);
+  assert.strictEqual(res.statusCode, 400);
+  assert.ok(res.body.error);
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- verify Nostr event signatures on the server
- respond with HTTP 400 when signatures fail or pubkey mismatch
- export new `eventHandler` for testing
- test server signature verification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b98a0c488331bd37b11b337d93d9