### PR TITLE
Implement book history viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js && node test/server_signature.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js && node test/server_signature.test.js && node test/bookHistory.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",

--- a/src/components/BookHistory.tsx
+++ b/src/components/BookHistory.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useNostr } from '../nostr';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+export interface BookHistoryProps {
+  bookId: string;
+  onClose?: () => void;
+}
+
+export const BookHistory: React.FC<BookHistoryProps> = ({ bookId, onClose }) => {
+  const { list, publish } = useNostr();
+  const [events, setEvents] = useState<NostrEvent[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const evts = await list([{ '#d': [bookId] }]);
+        evts.sort((a, b) => b.created_at - a.created_at);
+        setEvents(evts);
+      } catch {
+        setEvents([]);
+      }
+    })();
+  }, [bookId, list]);
+
+  const handleRevert = async (evt: NostrEvent) => {
+    await publish({ kind: evt.kind, content: evt.content, tags: evt.tags });
+    if (onClose) onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-2 sm:p-4">
+      <div className="w-full max-w-md max-h-screen space-y-2 overflow-y-auto rounded bg-[color:var(--clr-surface)] p-4">
+        <div className="flex items-center justify-between border-b pb-2">
+          <h2 className="text-lg font-medium">History</h2>
+          {onClose && (
+            <button onClick={onClose} aria-label="Close">
+              ×
+            </button>
+          )}
+        </div>
+        <div className="space-y-2">
+          {events.map((e) => (
+            <div key={e.id} className="space-y-2 rounded border p-2">
+              <div className="flex items-center justify-between gap-2">
+                <span>{new Date(e.created_at * 1000).toLocaleString()}</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setOpenId(openId === e.id ? null : e.id)}
+                    className="rounded border px-2 py-1 text-sm"
+                  >
+                    Preview
+                  </button>
+                  <button
+                    onClick={() => handleRevert(e)}
+                    className="rounded bg-primary-600 px-2 py-1 text-sm text-white"
+                  >
+                    Revert to this version
+                  </button>
+                </div>
+              </div>
+              {openId === e.id && (
+                <pre className="whitespace-pre-wrap text-xs">
+                  {e.content || JSON.stringify(e.tags)}
+                </pre>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -10,6 +10,7 @@ import { useNostr, fetchLongPostParts } from '../nostr';
 import { ChapterEditorModal } from '../components/ChapterEditorModal';
 import { BookMetadataEditor } from '../components/BookMetadataEditor';
 import { DeleteButton } from '../components/DeleteButton';
+import { BookHistory } from '../components/BookHistory';
 
 interface ChapterEvent {
   id: string;
@@ -37,6 +38,7 @@ export const BookDetailScreen: React.FC = () => {
     number: number;
   } | null>(null);
   const [editMeta, setEditMeta] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const canEdit = pubkey && authorPubkey && pubkey === authorPubkey;
 
   useEffect(() => {
@@ -154,6 +156,12 @@ export const BookDetailScreen: React.FC = () => {
             Add Chapter
           </button>
           <button
+            onClick={() => setShowHistory(true)}
+            className="rounded border px-3 py-1"
+          >
+            Versions
+          </button>
+          <button
             onClick={handleDeleteBook}
             className="rounded border px-3 py-1 text-red-600"
           >
@@ -239,6 +247,9 @@ export const BookDetailScreen: React.FC = () => {
           meta={meta}
           onClose={() => setEditMeta(false)}
         />
+      )}
+      {showHistory && bookId && (
+        <BookHistory bookId={bookId} onClose={() => setShowHistory(false)} />
       )}
     </div>
   );

--- a/test/bookHistory.test.js
+++ b/test/bookHistory.test.js
@@ -1,0 +1,60 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/BookHistory.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: ['react', './src/nostr.tsx', 'nostr-tools'],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  let publishEvt;
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return {
+          useNostr: () => ({
+            list: async () => [
+              { id: '1', kind: 41, content: 'c1', tags: [['d', 'book']], created_at: 1 },
+            ],
+            publish: async (evt) => { publishEvt = evt; },
+          }),
+        };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'BookHistory.js' });
+  const { BookHistory } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(BookHistory, { bookId: 'book' }));
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    const btn = renderer.root.findAll(
+      (n) => n.type === 'button' && n.children.includes('Revert')
+    )[0];
+    await btn.props.onClick();
+    await Promise.resolve();
+  });
+
+  assert.ok(publishEvt, 'publish should be called');
+  assert.strictEqual(publishEvt.kind, 41);
+  assert.strictEqual(publishEvt.content, 'c1');
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add `BookHistory` component to preview and revert to previous book versions
- link versions from `BookDetailScreen`
- test book history revert logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885bc653ea88331bffc3423ec5a5cf3