### PR TITLE
Add key helpers and recovery modal

### DIFF
--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -1,0 +1,36 @@
+import { nip19 } from 'nostr-tools';
+import { schnorr } from '@noble/curves/secp256k1';
+import { bytesToHex } from '@noble/hashes/utils';
+
+export function validatePrivKey(key: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(key);
+}
+
+export function importKey(input: string): string | null {
+  const str = input.trim();
+  if (!str) return null;
+  if (validatePrivKey(str)) return str.toLowerCase();
+  try {
+    const decoded = nip19.decode(str);
+    if (decoded.type === 'nsec') {
+      return bytesToHex(decoded.data as Uint8Array);
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export function loadKey(): string | null {
+  const raw = localStorage.getItem('privKey');
+  if (!raw) return null;
+  return importKey(raw);
+}
+
+export function saveKey(hex: string): void {
+  localStorage.setItem('privKey', hex);
+}
+
+export function generateKey(): string {
+  return bytesToHex(schnorr.utils.randomPrivateKey());
+}

--- a/src/validatePrivKey.ts
+++ b/src/validatePrivKey.ts
@@ -1,3 +1,0 @@
-export function validatePrivKey(key: string): boolean {
-  return /^[0-9a-f]{64}$/i.test(key);
-}

--- a/test/validatePrivKey.test.js
+++ b/test/validatePrivKey.test.js
@@ -1,6 +1,6 @@
 require('ts-node/register');
 const assert = require('assert');
-const { validatePrivKey } = require('../src/validatePrivKey');
+const { validatePrivKey } = require('../src/lib/keys');
 
 assert.strictEqual(validatePrivKey('a'.repeat(63)), false);
 assert.strictEqual(validatePrivKey('g'.repeat(64)), false);


### PR DESCRIPTION
## Summary
- implement `src/lib/keys.ts` with functions for key management
- update login logic in `NostrProvider` to use helpers and detect corrupted keys
- show a recovery modal allowing importing or generating keys
- wire up logout/login flows to clear and store keys
- adjust validation test to import from new module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885be7929ac833192d4ffc28f7b5a13