### PR TITLE
Add ReaderScreen

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import { DMModal } from './components/DMModal';
 import { useNostr } from './nostr';
 import { BookListScreen } from './screens/BookListScreen';
 import { BookDetailScreen } from './screens/BookDetailScreen';
+import { ReaderScreen } from './screens/ReaderScreen';
 import { Discover } from './components/Discover';
 import { Library } from './components/Library';
 import { BookPublishWizard } from './components/BookPublishWizard';
@@ -89,6 +90,7 @@ const AppRoutes: React.FC = () => {
           <Route path="/profile" element={<ProfileSettings />} />
           <Route path="/books" element={<BookListScreen />} />
           <Route path="/book/:bookId" element={<BookDetailScreen />} />
+          <Route path="/read/:bookId" element={<ReaderScreen />} />
           <Route path="*" element={<Navigate to="/discover" />} />
         </Routes>
       </main>

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import {
   DragDropContext,
   Droppable,
@@ -21,6 +21,7 @@ interface ChapterEvent {
 
 export const BookDetailScreen: React.FC = () => {
   const { bookId } = useParams<{ bookId: string }>();
+  const navigate = useNavigate();
   const ctx = useNostr();
   const { subscribe, publish, list, pubkey } = ctx;
   const [authorPubkey, setAuthorPubkey] = useState<string | null>(null);
@@ -137,6 +138,16 @@ export const BookDetailScreen: React.FC = () => {
           )}
           <h2 className="text-xl font-semibold">{meta.title}</h2>
           {meta.summary && <p>{meta.summary}</p>}
+          {bookId && (
+            <div>
+              <button
+                onClick={() => navigate(`/read/${bookId}`)}
+                className="mt-2 rounded border px-3 py-1"
+              >
+                Read Book
+              </button>
+            </div>
+          )}
         </div>
       )}
       {canEdit && (

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useNostr, fetchLongPostParts } from '../nostr';
+import { ReaderToolbar } from '../components/ReaderToolbar';
+import { ProgressBar } from '../components/ProgressBar';
+import { ReaderView } from '../components/ReaderView';
+import { useTheme } from '../ThemeProvider';
+import { useReadingStore } from '../store';
+
+export const ReaderScreen: React.FC = () => {
+  const { bookId } = useParams<{ bookId: string }>();
+  const navigate = useNavigate();
+  const ctx = useNostr();
+  const { subscribe } = ctx;
+  const { theme, setTheme } = useTheme();
+  const { updateProgress, finishBook } = useReadingStore();
+  const [title, setTitle] = React.useState('');
+  const [html, setHtml] = React.useState('');
+  const [percent, setPercent] = React.useState(0);
+  const [fontSize, setFontSize] = React.useState(16);
+
+  React.useEffect(() => {
+    if (!bookId) return;
+    const off = subscribe(
+      [{ kinds: [30023], ids: [bookId], limit: 1 }],
+      async (evt) => {
+        setTitle(evt.tags.find((t) => t[0] === 'title')?.[1] ?? '');
+        setHtml(await fetchLongPostParts(ctx, evt));
+      },
+    );
+    return off;
+  }, [bookId, subscribe, ctx]);
+
+  const handleFontSize = (d: 1 | -1) =>
+    setFontSize((f) => Math.min(24, Math.max(12, f + d * 2)));
+
+  if (!bookId) return null;
+
+  return (
+    <div className="flex h-full flex-col">
+      <ReaderToolbar
+        title={title}
+        percent={Math.round(percent)}
+        onBack={() => navigate(-1)}
+        onToggleTheme={() => setTheme(theme === 'dark' ? 'default' : 'dark')}
+        onFontSize={handleFontSize}
+        onBookmark={() => {}}
+      />
+      <ProgressBar value={percent} aria-label="Reading progress" />
+      <ReaderView
+        bookId={bookId}
+        html={html}
+        onPercentChange={(p) => {
+          setPercent(p);
+          updateProgress(bookId, p);
+        }}
+        className="flex-1"
+        style={{ fontSize }}
+      />
+      <div className="p-4">
+        <button
+          onClick={() => {
+            finishBook(bookId);
+            navigate(-1);
+          }}
+          className="w-full rounded border px-3 py-2"
+        >
+          Mark as finished
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- create ReaderScreen composed of ReaderToolbar, ProgressBar and ReaderView
- wire up text size controls, theme toggle and finish action
- add route `/read/:bookId` and open from book details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c664e1948331a5c723008356c3c8