### PR TITLE
Update spacing and card/button styling

### DIFF
--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -11,7 +11,7 @@ export interface AuthorCardProps {
  */
 export const AuthorCard: React.FC<AuthorCardProps> = ({ pubkey, name }) => {
   return (
-    <div className="flex items-center gap-2 rounded border p-2">
+    <div className="flex items-center gap-[var(--space-2)] rounded-[var(--radius-card)] border p-[var(--space-2)]">
       <div className="flex-1">
         <p className="font-medium">{name || pubkey}</p>
       </div>

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -21,14 +21,18 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
   const ctx = useNostr();
   const [status, setStatus] = useState<'idle' | 'zapping' | 'done'>('idle');
   const { toggleBookmark, bookmarks, pubkey, subscribe } = ctx;
-  const [attachments, setAttachments] = useState<{ id: string; mime: string; url: string }[]>([]);
+  const [attachments, setAttachments] = useState<
+    { id: string; mime: string; url: string }[]
+  >([]);
 
   useEffect(() => {
     const off = subscribe([{ kinds: [1064], '#e': [event.id] }], (evt) => {
       const mime = evt.tags.find((t) => t[0] === 'mime')?.[1];
       const url = evt.tags.find((t) => t[0] === 'url')?.[1];
       if (!mime || !url) return;
-      setAttachments((a) => (a.find((x) => x.id === evt.id) ? a : [...a, { id: evt.id, mime, url }]));
+      setAttachments((a) =>
+        a.find((x) => x.id === evt.id) ? a : [...a, { id: evt.id, mime, url }],
+      );
     });
     return off;
   }, [subscribe, event.id]);
@@ -54,7 +58,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
   };
 
   return (
-    <div className="rounded border p-2">
+    <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
       {event.repostedBy && (
         <p className="mb-1 text-xs text-gray-500">
           Reposted by {event.repostedBy}
@@ -87,7 +91,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         >
           <button
             onClick={handleZap}
-            className="rounded bg-yellow-500 px-2 py-1 text-white"
+            className="rounded-[var(--radius-button)] bg-yellow-500 px-[var(--space-2)] py-[var(--space-1)] text-white"
           >
             {status === 'zapping'
               ? 'Zapping...'
@@ -102,7 +106,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         <button
           onClick={handleFav}
           aria-label="Favorite"
-          className="rounded border px-2 py-1"
+          className="rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)]"
         >
           <FaHeart className="inline" />
         </button>

--- a/src/components/BookCardSkeleton.tsx
+++ b/src/components/BookCardSkeleton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Skeleton, TextSkeleton } from './Skeleton';
 
 export const BookCardSkeleton: React.FC = () => (
-  <div className="rounded border p-2 space-y-2">
+  <div className="rounded-[var(--radius-card)] border p-[var(--space-2)] space-y-[var(--space-2)]">
     <Skeleton className="h-32 w-24" />
     <TextSkeleton lines={1} className="w-3/4" />
     <TextSkeleton lines={1} />

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -30,7 +30,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Delete"
-      className={`rounded border px-2 py-1 ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
     >
       <FaTrash aria-hidden="true" />
     </button>

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -158,7 +158,7 @@ export const Discover: React.FC = () => {
       </div>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Trending Books</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
           {trending.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
@@ -176,7 +176,7 @@ export const Discover: React.FC = () => {
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">New Releases</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
           {newReleases.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
@@ -194,9 +194,11 @@ export const Discover: React.FC = () => {
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Recommended for You</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
           {noResults ? (
-            <p className="col-span-full text-center">No matching books found.</p>
+            <p className="col-span-full text-center">
+              No matching books found.
+            </p>
           ) : recommended.length === 0 ? (
             Array.from({ length: 6 }).map((_, i) => (
               <BookCardSkeleton key={i} />

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -29,7 +29,7 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
       onClick={toggle}
       className={
         className ??
-        'rounded bg-primary-600 px-2 py-1 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50'
+        'rounded-[var(--radius-button)] bg-primary-600 px-[var(--space-2)] py-[var(--space-1)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50'
       }
     >
       {following ? 'Unfollow' : 'Follow'}

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -37,7 +37,7 @@ export const LoginButton: React.FC = () => {
     return (
       <button
         onClick={logout}
-        className="rounded bg-primary-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        className="rounded-[var(--radius-button)] bg-primary-600 px-[var(--space-3)] py-[var(--space-2)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
       >
         Logout
       </button>
@@ -48,7 +48,7 @@ export const LoginButton: React.FC = () => {
       {hasWallet ? (
         <button
           onClick={handleWalletLogin}
-          className="rounded bg-primary-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className="rounded-[var(--radius-button)] bg-primary-600 px-[var(--space-3)] py-[var(--space-2)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
         >
           Login with Nostr
         </button>
@@ -63,7 +63,7 @@ export const LoginButton: React.FC = () => {
           {error && <div className="text-red-600">{error}</div>}
           <button
             onClick={handlePrivLogin}
-            className="rounded bg-primary-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+            className="rounded-[var(--radius-button)] bg-primary-600 px-[var(--space-3)] py-[var(--space-2)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
           >
             Login
           </button>

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -50,13 +50,18 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
     }
   };
 
-  const icon = type === 'vote' ? <FaThumbsUp className="inline" /> : <FaStar className="inline" />;
+  const icon =
+    type === 'vote' ? (
+      <FaThumbsUp className="inline" />
+    ) : (
+      <FaStar className="inline" />
+    );
 
   return (
     <button
       onClick={handleClick}
       aria-label={type === 'vote' ? 'Vote' : 'Favourite'}
-      className={`rounded border px-2 py-1 ${active ? 'border-primary-600 bg-primary-600 text-white' : ''} ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${active ? 'border-primary-600 bg-primary-600 text-white' : ''} ${className ?? ''}`}
     >
       {icon} {count > 0 ? count : ''}
     </button>

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -28,7 +28,7 @@ export const ReportButton: React.FC<ReportButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Report"
-      className={`rounded border px-2 py-1 ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
     >
       <FaFlag aria-hidden="true" />
     </button>

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -27,7 +27,7 @@ export const RepostButton: React.FC<RepostButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Repost"
-      className={`rounded border px-2 py-1 ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
     >
       <FaRetweet aria-hidden="true" />
     </button>


### PR DESCRIPTION
## Summary
- adjust grid columns in Discover screen
- use spacing variables and 9px radii for cards and buttons

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885c9eb4ca8833194e9794641ea651e