### PR TITLE
Improve accessibility labels

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -31,6 +31,7 @@ export const BottomNav: React.FC<BottomNavProps> = ({
   >
     {items.map(({ key, label, Icon }) => (
       <button
+        type="button"
         key={key}
         onClick={() => onChange(key)}
         aria-pressed={active === key}

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -146,6 +146,8 @@ export const Discover: React.FC = () => {
           <button
             key={t}
             onClick={() => setTag(t)}
+            aria-pressed={tag === t}
+            aria-label={t}
             className={`btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] ${
               tag === t
                 ? 'bg-primary-600 text-white'

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -65,7 +65,7 @@ export const ProfileScreen: React.FC = () => {
         {meta?.picture && (
           <img
             src={meta.picture}
-            alt="Avatar"
+            alt={`Avatar for ${meta?.name || pubkey}`}
             className="h-16 w-16 rounded-full object-cover"
           />
         )}


### PR DESCRIPTION
## Summary
- add descriptive avatar alt text in ProfileScreen
- expose active state for search chips via `aria-pressed`
- mark navigation buttons as type="button" to avoid form side effects

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885cbca4240833199b7696623980746