### PR TITLE
Add UI settings page

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -17,10 +17,23 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const theme = useSettings((s) => s.theme);
   const setTheme = useSettings((s) => s.setTheme);
+  const textSize = useSettings((s) => s.textSize);
+  const reduceMotion = useSettings((s) => s.reduceMotion);
 
   React.useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
+
+  React.useEffect(() => {
+    document.documentElement.style.fontSize = `${textSize}px`;
+  }, [textSize]);
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute(
+      'data-reduce-motion',
+      reduceMotion ? 'true' : 'false',
+    );
+  }, [reduceMotion]);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,14 @@ html {
   }
 }
 
+[data-reduce-motion='true'] .skeleton::after {
+  animation: none;
+}
+[data-reduce-motion='true'] .btn-tap,
+[data-reduce-motion='true'] .card-hover {
+  transition: none;
+}
+
 .btn-tap {
   @apply transition-transform duration-150 active:scale-110 focus-visible:outline-none focus-visible:[box-shadow:var(--focus-ring)];
 }

--- a/src/pages/UISettings.tsx
+++ b/src/pages/UISettings.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useSettings } from '../useSettings';
+import type { Theme } from '../ThemeProvider';
+
+const themes: Theme[] = ['dark', 'earthy', 'vibrant', 'pastel'];
+
+const UISettingsPage: React.FC = () => {
+  const theme = useSettings((s) => s.theme);
+  const setTheme = useSettings((s) => s.setTheme);
+  const yearlyGoal = useSettings((s) => s.yearlyGoal);
+  const setYearlyGoal = useSettings((s) => s.setYearlyGoal);
+  const textSize = useSettings((s) => s.textSize);
+  const setTextSize = useSettings((s) => s.setTextSize);
+  const reduceMotion = useSettings((s) => s.reduceMotion);
+  const setReduceMotion = useSettings((s) => s.setReduceMotion);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium">Theme</label>
+        <select
+          value={theme}
+          onChange={(e) => setTheme(e.target.value as Theme)}
+          className="w-full rounded border p-2"
+        >
+          {themes.map((t) => (
+            <option key={t} value={t}>
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Yearly reading goal</label>
+        <input
+          type="number"
+          min={1}
+          value={yearlyGoal}
+          onChange={(e) =>
+            setYearlyGoal(Math.max(1, parseInt(e.target.value, 10) || 1))
+          }
+          className="w-full rounded border p-2"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">
+          Font size ({textSize}px)
+        </label>
+        <input
+          type="range"
+          min={12}
+          max={24}
+          value={textSize}
+          onChange={(e) => setTextSize(parseInt(e.target.value, 10))}
+          className="w-full"
+        />
+      </div>
+      <div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={(e) => setReduceMotion(e.target.checked)}
+          />
+          Reduce motion
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default UISettingsPage;

--- a/src/useSettings.ts
+++ b/src/useSettings.ts
@@ -8,17 +8,27 @@ export interface SettingsState {
   density: Density;
   offlineMaxBooks: number;
   pushEnabled: boolean;
+  yearlyGoal: number;
+  reduceMotion: boolean;
   theme: import('./ThemeProvider').Theme;
   setTextSize: (size: number) => void;
   setDensity: (d: Density) => void;
   setOfflineMaxBooks: (n: number) => void;
   setPushEnabled: (v: boolean) => void;
+  setYearlyGoal: (n: number) => void;
+  setReduceMotion: (v: boolean) => void;
   setTheme: (t: import('./ThemeProvider').Theme) => void;
   hydrate: (
     data: Partial<
       Pick<
         SettingsState,
-        'textSize' | 'density' | 'offlineMaxBooks' | 'pushEnabled' | 'theme'
+        | 'textSize'
+        | 'density'
+        | 'offlineMaxBooks'
+        | 'pushEnabled'
+        | 'yearlyGoal'
+        | 'reduceMotion'
+        | 'theme'
       >
     >,
   ) => void;
@@ -31,11 +41,15 @@ export const useSettings = create<SettingsState>()(
       density: 'comfortable',
       offlineMaxBooks: 3,
       pushEnabled: false,
+      yearlyGoal: 12,
+      reduceMotion: false,
       theme: 'default',
       setTextSize: (textSize) => set({ textSize }),
       setDensity: (density) => set({ density }),
       setOfflineMaxBooks: (offlineMaxBooks) => set({ offlineMaxBooks }),
       setPushEnabled: (pushEnabled) => set({ pushEnabled }),
+      setYearlyGoal: (yearlyGoal) => set({ yearlyGoal }),
+      setReduceMotion: (reduceMotion) => set({ reduceMotion }),
       setTheme: (theme) => set({ theme }),
       hydrate: (data) => set(data),
     }),


### PR DESCRIPTION
## Summary
- create new `UISettings` page with theme, font size, reading goal and motion settings
- store new options (`yearlyGoal`, `reduceMotion`) in `useSettings`
- update `ThemeProvider` to apply text size and motion preferences
- handle reduced motion styles in `index.css`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885e13ac9088331bbdcea78841514b7