### PR TITLE
Add OfflineSettings page with cache info

### DIFF
--- a/src/offlineStore.ts
+++ b/src/offlineStore.ts
@@ -7,6 +7,9 @@ export interface OfflineBook {
 }
 
 const INDEX_KEY = 'offline-index';
+const LAST_SYNC_KEY = 'offline-last-sync';
+const MODE_KEY = 'offline-enabled';
+const BG_SYNC_KEY = 'bg-sync-enabled';
 
 function getMaxBooks(): number {
   try {
@@ -29,6 +32,7 @@ export async function saveOfflineBook(id: string, html: string): Promise<void> {
       await Promise.all(removed.map((r) => del(`offline-${r}`)));
     }
     await set(INDEX_KEY, index.slice(0, max));
+    await set(LAST_SYNC_KEY, Date.now());
   } catch {
     // ignore errors
   }
@@ -55,6 +59,7 @@ export async function removeOfflineBook(id: string): Promise<void> {
       (x) => x !== id,
     );
     await set(INDEX_KEY, index);
+    await set(LAST_SYNC_KEY, Date.now());
   } catch {
     // ignore errors
   }
@@ -65,6 +70,7 @@ export async function clearOfflineBooks(): Promise<void> {
     const index = (await get<string[]>(INDEX_KEY)) ?? [];
     await Promise.all(index.map((id) => del(`offline-${id}`)));
     await del(INDEX_KEY);
+    await set(LAST_SYNC_KEY, Date.now());
   } catch {
     // ignore errors
   }
@@ -78,7 +84,65 @@ export async function pruneOfflineBooks(max: number): Promise<void> {
       await Promise.all(removed.map((id) => del(`offline-${id}`)));
     }
     await set(INDEX_KEY, index.slice(0, max));
+    await set(LAST_SYNC_KEY, Date.now());
   } catch {
     // ignore errors
+  }
+}
+
+export async function getCacheSize(): Promise<number> {
+  try {
+    const index = (await get<string[]>(INDEX_KEY)) ?? [];
+    let total = 0;
+    for (const id of index) {
+      const html = await get<string>(`offline-${id}`);
+      if (html) total += new Blob([html]).size;
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+export async function getLastSynced(): Promise<number | null> {
+  try {
+    const ts = await get<number>(LAST_SYNC_KEY);
+    return ts ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setOfflineMode(enabled: boolean): Promise<void> {
+  try {
+    await set(MODE_KEY, enabled);
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function isOfflineMode(): Promise<boolean> {
+  try {
+    const val = await get<boolean>(MODE_KEY);
+    return val !== false;
+  } catch {
+    return true;
+  }
+}
+
+export async function setBackgroundSync(enabled: boolean): Promise<void> {
+  try {
+    await set(BG_SYNC_KEY, enabled);
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function isBackgroundSync(): Promise<boolean> {
+  try {
+    const val = await get<boolean>(BG_SYNC_KEY);
+    return val !== false;
+  } catch {
+    return true;
   }
 }

--- a/src/pages/OfflineSettings.tsx
+++ b/src/pages/OfflineSettings.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  clearOfflineBooks,
+  getCacheSize,
+  getLastSynced,
+  isBackgroundSync,
+  isOfflineMode,
+  setBackgroundSync,
+  setOfflineMode,
+} from '../offlineStore';
+
+const OfflineSettingsPage: React.FC = () => {
+  const [cacheSize, setCacheSize] = React.useState<number>(0);
+  const [lastSynced, setLastSynced] = React.useState<number | null>(null);
+  const [offlineMode, setOfflineModeState] = React.useState<boolean>(true);
+  const [bgSync, setBgSyncState] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    getCacheSize().then(setCacheSize);
+    getLastSynced().then(setLastSynced);
+    isOfflineMode().then(setOfflineModeState);
+    isBackgroundSync().then(setBgSyncState);
+  }, []);
+
+  const handleClear = async () => {
+    await clearOfflineBooks();
+    setCacheSize(0);
+    setLastSynced(Date.now());
+  };
+
+  const toggleOffline = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setOfflineModeState(val);
+    await setOfflineMode(val);
+  };
+
+  const toggleBgSync = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setBgSyncState(val);
+    await setBackgroundSync(val);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={offlineMode} onChange={toggleOffline} />
+          Offline mode
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={bgSync} onChange={toggleBgSync} />
+          Background sync
+        </label>
+      </div>
+      <div className="space-y-1 text-sm">
+        <p>Cache size: {(cacheSize / 1024).toFixed(1)} kB</p>
+        {lastSynced && (
+          <p>Last synced: {new Date(lastSynced).toLocaleString()}</p>
+        )}
+        <button onClick={handleClear} className="rounded border px-3 py-1 mt-2">
+          Clear Cached Books
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OfflineSettingsPage;


### PR DESCRIPTION
## Summary
- add offline-related helpers to `offlineStore`
- implement new `OfflineSettings` page that displays cache usage, last sync time, and toggles for offline/background sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885e3f97e9883318dfc1c4ada713d2f