### PR TITLE
Add NotificationSettings page

### DIFF
--- a/src/pages/NotificationSettings.tsx
+++ b/src/pages/NotificationSettings.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useSettings } from '../useSettings';
+import {
+  registerPushSubscription,
+  unregisterPushSubscription,
+} from '../push';
+import { useNotificationSettings } from '../useNotificationSettings';
+
+const NotificationSettingsPage: React.FC = () => {
+  const newBooks = useNotificationSettings((s) => s.newBooks);
+  const zapReceipts = useNotificationSettings((s) => s.zapReceipts);
+  const chatMentions = useNotificationSettings((s) => s.chatMentions);
+  const setNewBooks = useNotificationSettings((s) => s.setNewBooks);
+  const setZapReceipts = useNotificationSettings((s) => s.setZapReceipts);
+  const setChatMentions = useNotificationSettings((s) => s.setChatMentions);
+
+  const pushEnabled = useSettings((s) => s.pushEnabled);
+  const setPushEnabled = useSettings((s) => s.setPushEnabled);
+  const [supportsPush, setSupportsPush] = React.useState(false);
+
+  React.useEffect(() => {
+    setSupportsPush(
+      typeof window !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        'PushManager' in window,
+    );
+  }, []);
+
+  const handlePushToggle = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    if (val) await registerPushSubscription();
+    else await unregisterPushSubscription();
+    setPushEnabled(val);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={newBooks}
+            onChange={(e) => setNewBooks(e.target.checked)}
+          />
+          New book notifications
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={zapReceipts}
+            onChange={(e) => setZapReceipts(e.target.checked)}
+          />
+          Zap receipts
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={chatMentions}
+            onChange={(e) => setChatMentions(e.target.checked)}
+          />
+          Chat mentions
+        </label>
+        {supportsPush && (
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={pushEnabled}
+              onChange={handlePushToggle}
+            />
+            Enable push notifications
+          </label>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettingsPage;

--- a/src/useNotificationSettings.ts
+++ b/src/useNotificationSettings.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface NotificationSettingsState {
+  newBooks: boolean;
+  zapReceipts: boolean;
+  chatMentions: boolean;
+  setNewBooks: (v: boolean) => void;
+  setZapReceipts: (v: boolean) => void;
+  setChatMentions: (v: boolean) => void;
+  hydrate: (
+    data: Partial<
+      Pick<NotificationSettingsState, 'newBooks' | 'zapReceipts' | 'chatMentions'>
+    >,
+  ) => void;
+}
+
+export const useNotificationSettings = create<NotificationSettingsState>()(
+  persist(
+    (set) => ({
+      newBooks: true,
+      zapReceipts: true,
+      chatMentions: true,
+      setNewBooks: (newBooks) => set({ newBooks }),
+      setZapReceipts: (zapReceipts) => set({ zapReceipts }),
+      setChatMentions: (chatMentions) => set({ chatMentions }),
+      hydrate: (data) => set(data),
+    }),
+    { name: 'notification-settings' },
+  ),
+);


### PR DESCRIPTION
## Summary
- add `NotificationSettingsPage` component
- create a zustand store for notification settings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885e5681664833189a41118cd0da34d