### PR TITLE
Add advanced settings page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import { BookPublishWizard } from './components/BookPublishWizard';
 import { NotificationFeed } from './components/NotificationFeed';
 import ProfileSettingsPage from './pages/ProfileSettings';
 import DataExportPage from './pages/DataExport';
+import AdvancedSettingsPage from './pages/AdvancedSettings';
 import { ProfileScreen } from './screens/ProfileScreen';
 import { ToastProvider } from './components/ToastProvider';
 
@@ -93,9 +94,13 @@ const AppRoutes: React.FC = () => {
           <Route path="/profile" element={<ProfileScreen />} />
           <Route path="/profile/settings" element={<ProfileSettingsPage />} />
           <Route path="/export" element={<DataExportPage />} />
+          <Route path="/advanced" element={<AdvancedSettingsPage />} />
           <Route path="/books" element={<BookListScreen />} />
           <Route path="/book/:bookId" element={<BookDetailScreen />} />
-          <Route path="/book/:bookId/chapters" element={<ManageChaptersPage />} />
+          <Route
+            path="/book/:bookId/chapters"
+            element={<ManageChaptersPage />}
+          />
           <Route path="/read/:bookId" element={<ReaderScreen />} />
           <Route path="*" element={<Navigate to="/discover" />} />
         </Routes>

--- a/src/pages/AdvancedSettings.tsx
+++ b/src/pages/AdvancedSettings.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useSettings } from '../useSettings';
+import { useEventStore } from '../store/events';
+import { useNostr, setMaxEventSize, MAX_EVENT_SIZE } from '../nostr';
+import { useToast } from '../components/ToastProvider';
+
+const AdvancedSettingsPage: React.FC = () => {
+  const advancedMode = useSettings((s) => s.advancedMode);
+  const setAdvancedMode = useSettings((s) => s.setAdvancedMode);
+  const storeMax = useSettings((s) => s.maxEventSize);
+  const setStoreMax = useSettings((s) => s.setMaxEventSize);
+  const [maxSize, setMaxSize] = React.useState(
+    () => storeMax || MAX_EVENT_SIZE,
+  );
+
+  const { sendEvent } = useNostr();
+  const events = useEventStore((s) => Object.values(s.events));
+  const toast = useToast();
+
+  const relayLogs = React.useMemo(() => {
+    try {
+      return JSON.parse(localStorage.getItem('relay_logs') || '[]');
+    } catch {
+      return [] as any[];
+    }
+  }, [advancedMode]);
+
+  const handleClearLogs = () => {
+    localStorage.removeItem('relay_logs');
+  };
+
+  const handleRebroadcast = async () => {
+    for (const evt of events) {
+      try {
+        await sendEvent(evt);
+      } catch {
+        /* ignore individual errors */
+      }
+    }
+    toast('Re-broadcast complete');
+  };
+
+  const handleSaveSize = () => {
+    const size = Math.max(100, maxSize);
+    setStoreMax(size);
+    setMaxEventSize(size);
+  };
+
+  const version = (import.meta as any).env?.VITE_APP_VERSION || '';
+  const sha = (import.meta as any).env?.VITE_COMMIT_SHA || '';
+  const buildDate = (import.meta as any).env?.VITE_BUILD_DATE || '';
+
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={advancedMode}
+          onChange={(e) => setAdvancedMode(e.target.checked)}
+        />
+        Advanced mode
+      </label>
+      {advancedMode && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="mb-1 text-sm font-medium">Relay logs</h2>
+            {relayLogs.length > 0 ? (
+              <pre className="max-h-48 overflow-y-auto rounded border p-2 text-xs whitespace-pre-wrap break-all">
+                {JSON.stringify(relayLogs, null, 2)}
+              </pre>
+            ) : (
+              <p className="text-sm">No logs</p>
+            )}
+            <button
+              onClick={handleClearLogs}
+              className="mt-2 rounded border px-3 py-1"
+            >
+              Clear Logs
+            </button>
+          </div>
+          <div className="space-y-2">
+            <button
+              onClick={handleRebroadcast}
+              className="rounded border px-3 py-1"
+            >
+              Re-broadcast my events
+            </button>
+          </div>
+          <div>
+            <label className="block text-sm font-medium">
+              Max event size (bytes)
+            </label>
+            <input
+              type="number"
+              min={100}
+              value={maxSize}
+              onChange={(e) => setMaxSize(parseInt(e.target.value, 10) || 100)}
+              className="w-full rounded border p-2"
+            />
+            <button
+              onClick={handleSaveSize}
+              className="mt-2 rounded border px-3 py-1"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="text-sm text-gray-600 space-y-1">
+        <p>Version: {version}</p>
+        <p>Commit: {sha}</p>
+        <p>Built: {buildDate}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedSettingsPage;

--- a/src/useSettings.ts
+++ b/src/useSettings.ts
@@ -11,6 +11,8 @@ export interface SettingsState {
   yearlyGoal: number;
   reduceMotion: boolean;
   theme: import('./ThemeProvider').Theme;
+  advancedMode: boolean;
+  maxEventSize: number;
   setTextSize: (size: number) => void;
   setDensity: (d: Density) => void;
   setOfflineMaxBooks: (n: number) => void;
@@ -18,6 +20,8 @@ export interface SettingsState {
   setYearlyGoal: (n: number) => void;
   setReduceMotion: (v: boolean) => void;
   setTheme: (t: import('./ThemeProvider').Theme) => void;
+  setAdvancedMode: (v: boolean) => void;
+  setMaxEventSize: (n: number) => void;
   hydrate: (
     data: Partial<
       Pick<
@@ -29,6 +33,8 @@ export interface SettingsState {
         | 'yearlyGoal'
         | 'reduceMotion'
         | 'theme'
+        | 'advancedMode'
+        | 'maxEventSize'
       >
     >,
   ) => void;
@@ -44,6 +50,8 @@ export const useSettings = create<SettingsState>()(
       yearlyGoal: 12,
       reduceMotion: false,
       theme: 'default',
+      advancedMode: false,
+      maxEventSize: 1000,
       setTextSize: (textSize) => set({ textSize }),
       setDensity: (density) => set({ density }),
       setOfflineMaxBooks: (offlineMaxBooks) => set({ offlineMaxBooks }),
@@ -51,6 +59,8 @@ export const useSettings = create<SettingsState>()(
       setYearlyGoal: (yearlyGoal) => set({ yearlyGoal }),
       setReduceMotion: (reduceMotion) => set({ reduceMotion }),
       setTheme: (theme) => set({ theme }),
+      setAdvancedMode: (advancedMode) => set({ advancedMode }),
+      setMaxEventSize: (maxEventSize) => set({ maxEventSize }),
       hydrate: (data) => set(data),
     }),
     { name: 'settings-store' },


### PR DESCRIPTION
## Summary
- add advanced mode and max event size to settings store
- make `MAX_EVENT_SIZE` configurable
- create new AdvancedSettings page with relay log display, re-broadcast, and event size control
- expose AdvancedSettings route

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885eac6ae0c83319e32fcbc5971df8d