### PR TITLE
Unify theme options

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -3,6 +3,14 @@ import { useSettings } from './useSettings';
 
 export type Theme = 'default' | 'dark' | 'earthy' | 'vibrant' | 'pastel';
 
+export const THEMES: Theme[] = [
+  'default',
+  'dark',
+  'earthy',
+  'vibrant',
+  'pastel',
+];
+
 interface ThemeContextValue {
   theme: Theme;
   setTheme: (t: Theme | ((t: Theme) => Theme)) => void;

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { useTheme, Theme } from '../ThemeProvider';
-
-const themes: Theme[] = ['default', 'dark', 'earthy', 'vibrant', 'pastel'];
+import { useTheme, THEMES, Theme } from '../ThemeProvider';
 
 export const ThemeSwitcher: React.FC = () => {
   const { theme, setTheme } = useTheme();
@@ -12,7 +10,7 @@ export const ThemeSwitcher: React.FC = () => {
       className="ml-2 rounded border p-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
       aria-label="Theme"
     >
-      {themes.map((t) => (
+      {THEMES.map((t) => (
         <option value={t} key={t}>
           {t.charAt(0).toUpperCase() + t.slice(1)}
         </option>

--- a/src/pages/UISettings.tsx
+++ b/src/pages/UISettings.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useSettings } from '../useSettings';
 import type { Theme } from '../ThemeProvider';
-
-const themes: Theme[] = ['dark', 'earthy', 'vibrant', 'pastel'];
+import { THEMES } from '../ThemeProvider';
 
 const UISettingsPage: React.FC = () => {
   const theme = useSettings((s) => s.theme);
@@ -23,7 +22,7 @@ const UISettingsPage: React.FC = () => {
           onChange={(e) => setTheme(e.target.value as Theme)}
           className="w-full rounded border p-2"
         >
-          {themes.map((t) => (
+          {THEMES.map((t) => (
             <option key={t} value={t}>
               {t.charAt(0).toUpperCase() + t.slice(1)}
             </option>


### PR DESCRIPTION
## Summary
- centralize list of theme names in `ThemeProvider`
- use unified theme array in `ThemeSwitcher`
- use unified theme array in `UISettingsPage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885f7facab88331afb0ee70df083770