### PR TITLE
Add login modal with toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ export interface HeaderProps {
   children?: React.ReactNode;
   className?: string;
   'data-testid'?: string;
+  onLogin?: () => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -19,6 +20,7 @@ export const Header: React.FC<HeaderProps> = ({
   onSelectSuggestion,
   children,
   className,
+  onLogin,
   'data-testid': dataTestId,
 }) => {
   const [q, setQ] = React.useState('');
@@ -80,6 +82,14 @@ export const Header: React.FC<HeaderProps> = ({
         </ul>
       )}
       {children}
+      {onLogin && (
+        <button
+          onClick={onLogin}
+          className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          Login
+        </button>
+      )}
     </header>
   );
 };

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { useNostr, connectNostrWallet, nostrLogin } from '../nostr';
+import { importKey, validatePrivKey } from '../lib/keys';
+import { isValidUrl } from '../validators';
+
+export interface LoginModalProps {
+  onClose: () => void;
+}
+
+export const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
+  const ctx = useNostr();
+  const { login, logout, pubkey } = ctx;
+  const [tab, setTab] = React.useState<'priv' | 'nip07' | 'remote'>('priv');
+
+  const [privInput, setPrivInput] = React.useState('');
+  const [privError, setPrivError] = React.useState<string | null>(null);
+
+  const [remoteUrl, setRemoteUrl] = React.useState('');
+  const [remoteToken, setRemoteToken] = React.useState('');
+  const [remoteError, setRemoteError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const hasWallet = React.useMemo(() => Boolean((window as any).nostr), []);
+
+  const handlePrivLogin = () => {
+    const key = importKey(privInput);
+    if (!key || !validatePrivKey(key)) {
+      setPrivError('Invalid private key');
+      return;
+    }
+    try {
+      login(key);
+      setPrivError(null);
+      onClose();
+    } catch {
+      setPrivError('Invalid private key');
+    }
+  };
+
+  const handleWalletLogin = async () => {
+    setLoading(true);
+    try {
+      const pk = await connectNostrWallet();
+      if (!pk) throw new Error('Wallet not found');
+      await nostrLogin(ctx, pk);
+      onClose();
+    } catch (err: any) {
+      setPrivError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemoteLogin = async () => {
+    setLoading(true);
+    try {
+      const urlOk = isValidUrl(remoteUrl);
+      if (!urlOk || !remoteToken) {
+        setRemoteError('Enter a valid URL and token');
+        setLoading(false);
+        return;
+      }
+      const res = await fetch(`${remoteUrl.replace(/\/$/, '')}/pubkey`, {
+        headers: { Authorization: `Bearer ${remoteToken}` },
+      });
+      const data = await res.json();
+      if (!data.pubkey) throw new Error('Invalid response');
+      ctx.loginNip07(data.pubkey);
+      localStorage.setItem('remoteSignerUrl', remoteUrl);
+      localStorage.setItem('remoteSignerToken', remoteToken);
+      setRemoteError(null);
+      onClose();
+    } catch (err: any) {
+      setRemoteError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isPrivValid = Boolean(importKey(privInput));
+  const isRemoteValid = isValidUrl(remoteUrl) && Boolean(remoteToken);
+
+  if (pubkey) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-2">
+        <div className="w-full max-w-sm space-y-4 rounded bg-[color:var(--clr-surface)] p-4">
+          <p className="text-sm break-all">Logged in as {pubkey}</p>
+          <div className="flex justify-end gap-2">
+            <button onClick={logout} className="rounded border px-3 py-1">
+              Logout
+            </button>
+            <button onClick={onClose} className="rounded bg-primary-600 px-3 py-1 text-white">
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-2">
+      <div className="w-full max-w-sm space-y-4 rounded bg-[color:var(--clr-surface)] p-4">
+        <div className="flex gap-2">
+          <button
+            onClick={() => setTab('priv')}
+            className={`flex-1 rounded border px-2 py-1 ${tab === 'priv' ? 'bg-border' : ''}`}
+          >
+            Private Key
+          </button>
+          <button
+            onClick={() => setTab('nip07')}
+            className={`flex-1 rounded border px-2 py-1 ${tab === 'nip07' ? 'bg-border' : ''}`}
+          >
+            NIP-07
+          </button>
+          <button
+            onClick={() => setTab('remote')}
+            className={`flex-1 rounded border px-2 py-1 ${tab === 'remote' ? 'bg-border' : ''}`}
+          >
+            Remote
+          </button>
+        </div>
+        {tab === 'priv' && (
+          <div className="space-y-2">
+            <input
+              value={privInput}
+              onChange={(e) => setPrivInput(e.target.value)}
+              placeholder="nsec or hex"
+              className="w-full rounded border p-2"
+            />
+            {privError && <p className="text-red-600 text-sm">{privError}</p>}
+            <button
+              onClick={handlePrivLogin}
+              disabled={!isPrivValid || loading}
+              className="w-full rounded bg-primary-600 px-3 py-1 text-white disabled:opacity-50"
+            >
+              Login
+            </button>
+          </div>
+        )}
+        {tab === 'nip07' && (
+          <div className="space-y-2">
+            {!hasWallet && <p className="text-sm">Nostr wallet not detected.</p>}
+            {privError && <p className="text-red-600 text-sm">{privError}</p>}
+            <button
+              onClick={handleWalletLogin}
+              disabled={!hasWallet || loading}
+              className="w-full rounded bg-primary-600 px-3 py-1 text-white disabled:opacity-50"
+            >
+              Connect Wallet
+            </button>
+          </div>
+        )}
+        {tab === 'remote' && (
+          <div className="space-y-2">
+            <input
+              value={remoteUrl}
+              onChange={(e) => setRemoteUrl(e.target.value)}
+              placeholder="Signer URL"
+              className="w-full rounded border p-2"
+            />
+            <input
+              value={remoteToken}
+              onChange={(e) => setRemoteToken(e.target.value)}
+              placeholder="Auth token"
+              className="w-full rounded border p-2"
+            />
+            {remoteError && <p className="text-red-600 text-sm">{remoteError}</p>}
+            <button
+              onClick={handleRemoteLogin}
+              disabled={!isRemoteValid || loading}
+              className="w-full rounded bg-primary-600 px-3 py-1 text-white disabled:opacity-50"
+            >
+              Connect
+            </button>
+          </div>
+        )}
+        <div className="flex justify-end">
+          <button onClick={onClose} className="rounded px-3 py-1 border">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { Header } from './components/Header';
+import { LoginModal } from './components/LoginModal';
 import { search, Suggestion } from './search';
 import { BottomNav } from './components/BottomNav';
 import { ThemeProvider } from './ThemeProvider';
@@ -48,6 +49,7 @@ const AppRoutes: React.FC = () => {
     return 'discover';
   }, [location.pathname]);
   const [chatOpen, setChatOpen] = React.useState(false);
+  const [loginOpen, setLoginOpen] = React.useState(false);
   const { contacts } = useNostr();
   const [suggestions, setSuggestions] = React.useState<Suggestion[]>([]);
 
@@ -77,6 +79,7 @@ const AppRoutes: React.FC = () => {
         onSearch={handleSearch}
         suggestions={suggestions}
         onSelectSuggestion={handleSelectSuggestion}
+        onLogin={() => setLoginOpen(true)}
       >
         <button
           onClick={() => setChatOpen(true)}
@@ -115,6 +118,7 @@ const AppRoutes: React.FC = () => {
       {chatOpen && contacts[0] && (
         <DMModal to={contacts[0]} onClose={() => setChatOpen(false)} />
       )}
+      {loginOpen && <LoginModal onClose={() => setLoginOpen(false)} />}
     </AppShell>
   );
 };


### PR DESCRIPTION
## Summary
- add `LoginModal` component with private key, NIP‑07 and remote signer flows
- show login button in `Header`
- toggle modal state from `index.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885fa72d3b4833184df7253c121f0aa