### PR TITLE
Enhance discover search and tags

### DIFF
--- a/src/components/Illustration.tsx
+++ b/src/components/Illustration.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface IllustrationProps {
+  text: string;
+}
+
+export const Illustration: React.FC<IllustrationProps> = ({ text }) => (
+  <div className="flex flex-col items-center gap-2 py-8" role="img" aria-label={text}>
+    <span className="text-6xl">📚</span>
+    <p className="text-center text-text-muted">{text}</p>
+  </div>
+);


### PR DESCRIPTION
## Summary
- compute discover tag options from published books
- add a Clear button to the discover search field
- show an illustration when searches have no results
- debounce search suggestions and persist search history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885fbf555b083319ea19c310430d970