### PR TITLE
Add offline queue for nostr actions

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,11 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getOfflineEdits } from './lib/offlineSync';
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
-export const AppShell: React.FC<AppShellProps> = ({ children }) => (
-  <div className="min-h-screen bg-[color:var(--clr-surface)] text-[color:var(--clr-text)]">
-    {children}
-  </div>
-);
+export const AppShell: React.FC<AppShellProps> = ({ children }) => {
+  const [pending, setPending] = useState(0);
+
+  useEffect(() => {
+    getOfflineEdits().then((edits) => setPending(edits.length));
+    const handler = (e: Event) => {
+      const count = (e as CustomEvent<number>).detail as number;
+      setPending(count);
+    };
+    window.addEventListener('offline-queue', handler);
+    if (navigator.serviceWorker?.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'request-edits' });
+    }
+    return () => window.removeEventListener('offline-queue', handler);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[color:var(--clr-surface)] text-[color:var(--clr-text)]">
+      {pending > 0 && (
+        <div className="bg-yellow-200 text-center text-sm p-2">
+          {pending} action{pending !== 1 ? 's' : ''} pending sync
+        </div>
+      )}
+      {children}
+    </div>
+  );
+};

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FaRetweet } from 'react-icons/fa';
 import { useNostr, publishRepost } from '../nostr';
+import { queueOfflineEdit } from '../lib/offlineSync';
 import { useToast } from './ToastProvider';
 
 export interface RepostButtonProps {
@@ -17,6 +18,15 @@ export const RepostButton: React.FC<RepostButtonProps> = ({
 
   const handleClick = async () => {
     try {
+      if (!navigator.onLine) {
+        await queueOfflineEdit({
+          id: Math.random().toString(36).slice(2),
+          type: 'repost',
+          data: { target },
+        });
+        toast('Saved offline, will sync later');
+        return;
+      }
       await publishRepost(ctx, target);
     } catch {
       toast('Action failed', { type: 'error' });


### PR DESCRIPTION
## Summary
- support offline `publish`, `vote`, and `repost` events
- enqueue votes and reposts when offline
- show pending action banner in `AppShell`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885fffc9d488331b2061fa3c4a58259