### PR TITLE
Add responsive columns to Discover grid

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -182,7 +182,7 @@ export const Discover: React.FC = () => {
       </div>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Trending Books</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
           {trending.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
@@ -200,7 +200,7 @@ export const Discover: React.FC = () => {
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">New Releases</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
           {newReleases.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
@@ -218,7 +218,7 @@ export const Discover: React.FC = () => {
       </section>
       <section className="p-4">
         <h2 className="mb-2 font-semibold">Recommended for You</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
           {noResults ? (
             <div className="col-span-full">
               <Illustration text="No matching books found." />

--- a/test/discoverGridLayout.test.js
+++ b/test/discoverGridLayout.test.js
@@ -1,0 +1,81 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const { MemoryRouter } = require('react-router-dom');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/components/Discover.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-router-dom',
+      './src/nostr.tsx',
+      './src/components/BookCard.tsx',
+      './src/components/BookCardSkeleton.tsx',
+      './src/components/OnboardingTooltip.tsx',
+      './src/analytics.ts',
+      './src/components/CommunityFeed.tsx',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const sandbox = {
+    require: (p) => {
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [] }) };
+      }
+      if (p.endsWith('BookCard') || p.endsWith('BookCard.tsx')) {
+        return { BookCard: () => React.createElement('div') };
+      }
+      if (p.endsWith('BookCardSkeleton') || p.endsWith('BookCardSkeleton.tsx')) {
+        return { BookCardSkeleton: () => React.createElement('div') };
+      }
+      if (p.endsWith('OnboardingTooltip') || p.endsWith('OnboardingTooltip.tsx')) {
+        return { OnboardingTooltip: ({ children }) => React.createElement('div', null, children) };
+      }
+      if (p.endsWith('CommunityFeed') || p.endsWith('CommunityFeed.tsx')) {
+        return { CommunityFeed: () => React.createElement('div') };
+      }
+      if (p.endsWith('analytics') || p.endsWith('analytics.ts')) {
+        return { logEvent: () => {} };
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'Discover.js' });
+  const { Discover } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(
+        MemoryRouter,
+        { initialEntries: ['/discover'] },
+        React.createElement(Discover)
+      )
+    );
+    await Promise.resolve();
+  });
+
+  const grids = renderer.root.findAll(
+    (n) => n.type === 'div' && n.props.className && n.props.className.includes('grid-cols-1')
+  );
+  assert.ok(grids.length >= 3, 'Expected grid containers');
+  grids.forEach((g) => {
+    const cls = g.props.className;
+    assert.ok(cls.includes('md:grid-cols-2'), 'md:grid-cols-2 missing');
+    assert.ok(cls.includes('lg:grid-cols-4'), 'lg:grid-cols-4 missing');
+  });
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- update Discover grid sections to use `md:grid-cols-2`
- verify responsive classes through new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886051aee14833199a63d935d2d5a87