### PR TITLE
Add layout wrapper and header back button

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { FaChevronLeft } from 'react-icons/fa';
 
 export interface HeaderProps {
   onSearch: (q: string) => void;
@@ -25,6 +27,9 @@ export const Header: React.FC<HeaderProps> = ({
 }) => {
   const [q, setQ] = React.useState('');
   const [active, setActive] = React.useState(-1);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const nested = location.pathname.split('/').filter(Boolean).length > 1;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!suggestions || suggestions.length === 0) return;
@@ -43,6 +48,15 @@ export const Header: React.FC<HeaderProps> = ({
 
   return (
     <header className={className} data-testid={dataTestId} role="search">
+      {nested && (
+        <button
+          onClick={() => navigate(-1)}
+          aria-label="Back"
+          className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          <FaChevronLeft />
+        </button>
+      )}
       <form
         onSubmit={(e) => {
           e.preventDefault();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import {
   Navigate,
   useNavigate,
   useLocation,
+  Outlet,
 } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { Header } from './components/Header';
@@ -30,7 +31,7 @@ import SettingsHome from './pages/SettingsHome';
 import { ProfileScreen } from './screens/ProfileScreen';
 import { ToastProvider } from './components/ToastProvider';
 
-const AppRoutes: React.FC = () => {
+const Layout: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const active = React.useMemo<
@@ -90,29 +91,7 @@ const AppRoutes: React.FC = () => {
         </button>
       </Header>
       <main id="main" className="p-[var(--space-4)]">
-        <Routes>
-          <Route path="/discover" element={<Discover />} />
-          <Route path="/library" element={<LibraryPage />} />
-          <Route path="/write" element={<BookPublishWizard />} />
-          <Route path="/activity" element={<NotificationFeed />} />
-          <Route path="/profile" element={<ProfileScreen />} />
-          <Route path="/settings" element={<SettingsHome />} />
-          <Route path="/settings/profile" element={<ProfileSettingsPage />} />
-          <Route path="/settings/ui" element={<UISettingsPage />} />
-          <Route path="/settings/offline" element={<OfflineSettingsPage />} />
-          <Route
-            path="/profile/settings"
-            element={<Navigate replace to="/settings/profile" />}
-          />
-          <Route path="/books" element={<BookListScreen />} />
-          <Route path="/book/:bookId" element={<BookDetailScreen />} />
-          <Route
-            path="/book/:bookId/chapters"
-            element={<ManageChaptersPage />}
-          />
-          <Route path="/read/:bookId" element={<ReaderScreen />} />
-          <Route path="*" element={<Navigate to="/discover" />} />
-        </Routes>
+        <Outlet />
       </main>
       <BottomNav active={active} onChange={handleChange} />
       {chatOpen && contacts[0] && (
@@ -122,6 +101,29 @@ const AppRoutes: React.FC = () => {
     </AppShell>
   );
 };
+
+const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<Layout />}>
+      <Route index element={<Navigate to="discover" />} />
+      <Route path="discover" element={<Discover />} />
+      <Route path="library" element={<LibraryPage />} />
+      <Route path="write" element={<BookPublishWizard />} />
+      <Route path="activity" element={<NotificationFeed />} />
+      <Route path="profile" element={<ProfileScreen />} />
+      <Route path="settings" element={<SettingsHome />} />
+      <Route path="settings/profile" element={<ProfileSettingsPage />} />
+      <Route path="settings/ui" element={<UISettingsPage />} />
+      <Route path="settings/offline" element={<OfflineSettingsPage />} />
+      <Route path="profile/settings" element={<Navigate replace to="/settings/profile" />} />
+      <Route path="books" element={<BookListScreen />} />
+      <Route path="book/:bookId" element={<BookDetailScreen />} />
+      <Route path="book/:bookId/chapters" element={<ManageChaptersPage />} />
+      <Route path="read/:bookId" element={<ReaderScreen />} />
+      <Route path="*" element={<Navigate to="/discover" />} />
+    </Route>
+  </Routes>
+);
 
 export const App: React.FC = () => (
   <ToastProvider>


### PR DESCRIPTION
## Summary
- restructure routing into a layout component wrapped by `AppShell`
- show a back chevron in `Header` when on nested routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688608cfd7f8833197964e07b8643727