### PR TITLE
Refactor nostr modules

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getOfflineEdits } from './lib/offlineSync';
+import { getOfflineEdits } from './nostr/offline';
 
 interface AppShellProps {
   children: React.ReactNode;

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNostr, zap } from '../nostr';
+import { useNostr } from '../nostr';
+import { zap } from '../nostr/events';
 import { ReactionButton } from './ReactionButton';
 import { RepostButton } from './RepostButton';
 import { DeleteButton } from './DeleteButton';

--- a/src/components/BookMetadataEditor.tsx
+++ b/src/components/BookMetadataEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNostr, publishBookMeta } from '../nostr';
-import { queueOfflineEdit } from '../lib/offlineSync';
+import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
 
 export interface BookMetadataEditorProps {

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
-import { useNostr, publishLongPost, publishBookMeta } from '../nostr';
+import { useNostr } from '../nostr';
+import { publishLongPost, publishBookMeta } from '../nostr/events';
 import { useToast } from './ToastProvider';
 import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';

--- a/src/components/ChapterEditorModal.tsx
+++ b/src/components/ChapterEditorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { useNostr, publishLongPost } from '../nostr';
-import { queueOfflineEdit } from '../lib/offlineSync';
+import { useNostr } from '../nostr';
+import { publishLongPost } from '../nostr/events';
+import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
 
 interface Props {

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -11,7 +11,9 @@ if (typeof window === 'undefined') {
   FixedSizeList = require('react-window').FixedSizeList;
 }
 import type { Event as NostrEvent } from 'nostr-tools';
-import { useNostr, sendDM, getPrivKey } from '../nostr';
+import { useNostr } from '../nostr';
+import { sendDM } from '../nostr/events';
+import { getPrivKey } from '../nostr/auth';
 import { OnboardingTooltip } from './OnboardingTooltip';
 
 interface Message {

--- a/src/components/DelegationManager.tsx
+++ b/src/components/DelegationManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { createDelegationTag, getPrivKey } from '../nostr';
+import { createDelegationTag, getPrivKey } from '../nostr/auth';
 import { OnboardingTooltip } from './OnboardingTooltip';
 
 /**

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { FaThumbsUp, FaStar } from 'react-icons/fa';
-import { useNostr, publishVote, publishFavourite } from '../nostr';
-import { queueOfflineEdit } from '../lib/offlineSync';
+import { useNostr } from '../nostr';
+import { publishVote, publishFavourite } from '../nostr/events';
+import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
 import type { Event as NostrEvent } from 'nostr-tools';
 

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { FaRetweet } from 'react-icons/fa';
-import { useNostr, publishRepost } from '../nostr';
-import { queueOfflineEdit } from '../lib/offlineSync';
+import { useNostr } from '../nostr';
+import { publishRepost } from '../nostr/events';
+import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
 
 export interface RepostButtonProps {

--- a/src/nostr/events.ts
+++ b/src/nostr/events.ts
@@ -1,0 +1,253 @@
+import { TextEncoder as UtilTextEncoder } from 'util';
+if (typeof globalThis.TextEncoder === "undefined") { (globalThis as any).TextEncoder = UtilTextEncoder; }
+import type { Event as NostrEvent } from 'nostr-tools';
+import { getPublicKey } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+import type { NostrContextValue } from '../nostr';
+import { MAX_EVENT_SIZE } from '../nostr';
+import { getPrivKey } from './auth';
+
+const encoder = typeof TextEncoder === 'undefined' ? new UtilTextEncoder() : new TextEncoder();
+
+export async function publishLongPost(
+  ctx: NostrContextValue,
+  data: {
+    title: string;
+    summary?: string;
+    content: string;
+    tags?: string[];
+    cover?: string;
+    extraTags?: string[][];
+  },
+  pow = 0,
+) {
+  const tags: string[][] = [];
+  if (data.title) tags.push(['title', data.title]);
+  if (data.summary) tags.push(['summary', data.summary]);
+  if (data.cover) tags.push(['image', data.cover]);
+  data.tags?.forEach((t) => tags.push(['t', t]));
+  if (data.extraTags) tags.push(...data.extraTags);
+
+  const sliceContent = (text: string) => {
+    const parts: string[] = [];
+    let buf = '';
+    let size = 0;
+    for (const ch of text) {
+      const b = encoder.encode(ch).length;
+      if (size + b > MAX_EVENT_SIZE && buf) {
+        parts.push(buf);
+        buf = ch;
+        size = b;
+      } else {
+        buf += ch;
+        size += b;
+      }
+    }
+    if (buf) parts.push(buf);
+    return parts;
+  };
+
+  const parts = sliceContent(data.content);
+  if (parts.length === 1) {
+    return ctx.publish(
+      { kind: 30023, content: data.content, tags },
+      undefined,
+      pow,
+    );
+  }
+
+  const dTag = Math.random().toString(36).slice(2);
+  let first: NostrEvent | null = null;
+  for (let i = 0; i < parts.length; i++) {
+    const ptTags = [...tags, ['d', dTag], ['part', String(i + 1)]];
+    const evt = await ctx.publish(
+      { kind: 30023, content: parts[i], tags: ptTags },
+      undefined,
+      pow,
+    );
+    if (i === 0) first = evt;
+  }
+  return first!;
+}
+
+export async function fetchLongPostParts(
+  ctx: NostrContextValue,
+  evt: NostrEvent,
+): Promise<string> {
+  const d = evt.tags.find((t) => t[0] === 'd')?.[1];
+  if (!d) return evt.content;
+  const parts = await ctx.list([
+    { kinds: [evt.kind], '#d': [d], authors: [evt.pubkey] },
+  ]);
+  const sorted = parts.sort((a, b) => {
+    const pa = parseInt(a.tags.find((t) => t[0] === 'part')?.[1] ?? '1', 10);
+    const pb = parseInt(b.tags.find((t) => t[0] === 'part')?.[1] ?? '1', 10);
+    return pa - pb;
+  });
+  return sorted.map((p) => p.content).join('');
+}
+
+export async function publishBookMeta(
+  ctx: NostrContextValue,
+  bookId: string,
+  meta: { title?: string; summary?: string; cover?: string; tags?: string[] },
+  pow = 0,
+) {
+  const tags: string[][] = [['d', bookId]];
+  if (meta.title) tags.push(['title', meta.title]);
+  if (meta.summary) tags.push(['summary', meta.summary]);
+  if (meta.cover) tags.push(['image', meta.cover]);
+  meta.tags?.forEach((t) => tags.push(['t', t]));
+  return ctx.publish({ kind: 41, content: '', tags }, undefined, pow);
+}
+
+export async function publishVote(ctx: NostrContextValue, target: string) {
+  return ctx.publish({ kind: 7, content: '+', tags: [['e', target]] });
+}
+
+export async function publishFavourite(ctx: NostrContextValue, target: string) {
+  return ctx.publish({ kind: 7, content: '★', tags: [['e', target]] });
+}
+
+export async function publishRepost(ctx: NostrContextValue, target: string) {
+  return ctx.publish({ kind: 6, content: '', tags: [['e', target]] });
+}
+
+export async function publishAttachment(
+  ctx: NostrContextValue,
+  data: { mime: string; url: string; bookId?: string },
+) {
+  const tags: string[][] = [
+    ['mime', data.mime],
+    ['url', data.url],
+  ];
+  if (data.bookId) tags.push(['e', data.bookId]);
+  return ctx.publish({ kind: 1064, content: '', tags });
+}
+
+export async function sendDM(ctx: NostrContextValue, to: string, text: string) {
+  const priv = getPrivKey();
+  let cipher: string;
+  if (priv) {
+    cipher = await (await import('nostr-tools')).nip04.encrypt(priv, to, text);
+  } else {
+    const nostr = (window as any).nostr;
+    if (!nostr?.nip04?.encrypt) throw new Error('not logged in');
+    cipher = await nostr.nip04.encrypt(to, text);
+  }
+  return ctx.publish({ kind: 4, content: cipher, tags: [['p', to]] });
+}
+
+export async function sendGroupDM(
+  ctx: NostrContextValue,
+  to: string[],
+  text: string,
+) {
+  const priv = getPrivKey();
+  if (!priv) throw new Error('not logged in');
+  const nt = await import('nostr-tools');
+  const privBytes = hexToBytes(priv);
+  const myPub = getPublicKey(privBytes);
+  const recipients = to
+    .filter((p) => p !== myPub)
+    .map((p) => ({ publicKey: p }));
+  const events = nt.nip17.wrapManyEvents(privBytes, recipients, text);
+  for (const e of events) {
+    await ctx.sendEvent(e);
+  }
+  return events;
+}
+
+export async function verifyNip05(handle: string, pubkey: string) {
+  const [name, domain] = handle.split('@');
+  if (!name || !domain) return false;
+  try {
+    const res = await fetch(
+      `https://${domain}/.well-known/nostr.json?name=${name}`,
+    );
+    const data = await res.json();
+    return data.names?.[name] === pubkey;
+  } catch {
+    return false;
+  }
+}
+
+export async function zap(
+  ctx: NostrContextValue,
+  event: NostrEvent,
+  amount = 1,
+) {
+  const meta = await new Promise<Record<string, any> | null>((resolve) => {
+    let done = false;
+    const off = ctx.subscribe(
+      [{ kinds: [0], authors: [event.pubkey], limit: 1 }],
+      (evt) => {
+        if (done) return;
+        done = true;
+        off();
+        try {
+          resolve(JSON.parse(evt.content));
+        } catch {
+          resolve(null);
+        }
+      },
+    );
+    setTimeout(() => {
+      if (!done) {
+        off();
+        resolve(null);
+      }
+    }, 5000);
+  });
+
+  const address = meta?.lud16 as string | undefined;
+  if (!address) throw new Error('missing lightning address');
+  const [name, domain] = address.split('@');
+  const infoRes = await fetch(`https://${domain}/.well-known/lnurlp/${name}`);
+  const info = await infoRes.json();
+  const msats = Math.max(info.minSendable, amount * 1000);
+
+  const relays = ctx.relays;
+  const zapReq = await ctx.publish({
+    kind: 9734,
+    content: '',
+    tags: [
+      ['p', event.pubkey],
+      ['e', event.id],
+      ['relays', ...relays],
+      ['amount', msats.toString()],
+    ],
+  });
+
+  const nostr = encodeURIComponent(JSON.stringify(zapReq));
+  const cb = `${info.callback}?amount=${msats}&nostr=${nostr}`;
+  const invRes = await fetch(cb);
+  const inv = await invRes.json();
+  const invoice: string = inv.pr;
+
+  const webln = (window as any).webln;
+  if (webln && webln.sendPayment) {
+    try {
+      await webln.enable();
+      await webln.sendPayment(invoice);
+    } catch {
+      window.open(`lightning:${invoice}`);
+    }
+  } else {
+    window.open(`lightning:${invoice}`);
+  }
+
+  await new Promise<void>((resolve) => {
+    const off = ctx.subscribe(
+      [{ kinds: [9735], '#bolt11': [invoice], limit: 1 }],
+      () => {
+        off();
+        resolve();
+      },
+    );
+    setTimeout(() => {
+      off();
+      resolve();
+    }, 30000);
+  });
+}

--- a/src/nostr/offline.ts
+++ b/src/nostr/offline.ts
@@ -5,7 +5,7 @@ import {
   publishLongPost,
   publishRepost,
   publishVote,
-} from '../nostr';
+} from "./events";
 
 export interface OfflineEdit {
   id: string;

--- a/src/pages/ManageChapters.tsx
+++ b/src/pages/ManageChapters.tsx
@@ -9,7 +9,8 @@ import {
 import type { Event as NostrEvent, EventTemplate } from 'nostr-tools';
 import { finalizeEvent } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
-import { useNostr, getPrivKey } from '../nostr';
+import { useNostr } from '../nostr';
+import { getPrivKey } from '../nostr/auth';
 import { ChapterEditorModal } from '../components/ChapterEditorModal';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';

--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import type { Event as NostrEvent, EventTemplate } from 'nostr-tools';
 import { finalizeEvent } from 'nostr-tools';
 import { hexToBytes } from '@noble/hashes/utils';
-import { useNostr, verifyNip05, getPrivKey } from '../nostr';
+import { useNostr } from '../nostr';
+import { verifyNip05 } from '../nostr/events';
+import { getPrivKey } from '../nostr/auth';
 import { isValidUrl, isValidNip05 } from '../validators';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';

--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -6,7 +6,8 @@ import {
   Draggable,
   DropResult,
 } from '@hello-pangea/dnd';
-import { useNostr, fetchLongPostParts } from '../nostr';
+import { useNostr } from '../nostr';
+import { fetchLongPostParts } from '../nostr/events';
 import { ChapterEditorModal } from '../components/ChapterEditorModal';
 import { BookMetadataEditor } from '../components/BookMetadataEditor';
 import { DeleteButton } from '../components/DeleteButton';

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useNostr, fetchLongPostParts } from '../nostr';
+import { useNostr } from '../nostr';
+import { fetchLongPostParts } from '../nostr/events';
 import { ReaderToolbar } from '../components/ReaderToolbar';
 import { ProgressBar } from '../components/ProgressBar';
 import { ReaderView } from '../components/ReaderView';

--- a/test/bookPublishMeta.test.js
+++ b/test/bookPublishMeta.test.js
@@ -17,7 +17,7 @@ const path = require('path');
       'react',
       'dompurify',
       'marked',
-      './src/nostr.tsx',
+      './src/nostr.tsx','./src/nostr/events.ts',
       './src/achievements.ts',
       './src/components/ToastProvider.tsx',
     ],
@@ -29,12 +29,12 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({}) };
+      }
+      if (p === './src/nostr/events.ts') {
         return {
-          useNostr: () => ({}),
           publishLongPost: async () => ({ id: 'abc123' }),
-          publishBookMeta: async (...args) => {
-            metaArgs = args;
-          },
+          publishBookMeta: async (...args) => { metaArgs = args; },
         };
       }
       if (p === './src/achievements.ts') {

--- a/test/bookPublishToast.test.js
+++ b/test/bookPublishToast.test.js
@@ -17,7 +17,7 @@ const path = require('path');
       'react',
       'dompurify',
       'marked',
-      './src/nostr.tsx',
+      './src/nostr.tsx','./src/nostr/events.ts',
       './src/achievements.ts',
       './src/components/ToastProvider.tsx',
     ],
@@ -28,7 +28,10 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
-        return { useNostr: () => ({}), publishLongPost: async () => { throw new Error('fail'); } };
+        return { useNostr: () => ({}) };
+      }
+      if (p === './src/nostr/events.ts') {
+        return { publishLongPost: async () => { throw new Error('fail'); } };
       }
       if (p === './src/achievements.ts') {
         return { reportBookPublished: () => {} };

--- a/test/reactionButtonToast.test.js
+++ b/test/reactionButtonToast.test.js
@@ -16,7 +16,7 @@ const path = require('path');
     external: [
       'react',
       'react-icons/fa',
-      './src/nostr.tsx',
+      './src/nostr.tsx','./src/nostr/events.ts',
       './src/components/ToastProvider.tsx',
       'nostr-tools',
     ],
@@ -27,15 +27,17 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({ subscribe: () => () => {}, pubkey: '1' }) };
+      }
+      if (p === './src/nostr/events.ts') {
         return {
-          useNostr: () => ({ subscribe: () => () => {}, pubkey: '1' }),
           publishVote: async () => { throw new Error('fail'); },
           publishFavourite: async () => { throw new Error('fail'); },
         };
       }
-      if (p === './src/components/ToastProvider.tsx') {
-        return { useToast: () => (msg) => calls.push(msg) };
-      }
+        if (p === "./src/components/ToastProvider.tsx") {
+          return { useToast: () => (msg) => calls.push(msg) };
+        }
       if (p === 'react-icons/fa') {
         return { FaThumbsUp: () => React.createElement('div'), FaStar: () => React.createElement('div') };
       }

--- a/test/repostButtonToast.test.js
+++ b/test/repostButtonToast.test.js
@@ -16,7 +16,7 @@ const path = require('path');
     external: [
       'react',
       'react-icons/fa',
-      './src/nostr.tsx',
+      './src/nostr.tsx','./src/nostr/events.ts',
       './src/components/ToastProvider.tsx',
     ],
   });
@@ -25,17 +25,17 @@ const path = require('path');
   const calls = [];
   const sandbox = {
     require: (p) => {
-      if (p === './src/nostr.tsx') {
-        return {
-          useNostr: () => ({}),
-          publishRepost: async () => { throw new Error('fail'); },
-        };
+      if (p === "./src/nostr.tsx") {
+        return { useNostr: () => ({}) };
       }
-      if (p === './src/components/ToastProvider.tsx') {
+      if (p === "./src/nostr/events.ts") {
+        return { publishRepost: async () => { throw new Error("fail"); } };
+      }
+      if (p === "./src/components/ToastProvider.tsx") {
         return { useToast: () => (msg) => calls.push(msg) };
       }
-      if (p === 'react-icons/fa') {
-        return { FaRetweet: () => React.createElement('div') };
+      if (p === "react-icons/fa") {
+        return { FaRetweet: () => React.createElement("div") };
       }
       return require(p);
     },
@@ -43,9 +43,6 @@ const path = require('path');
     exports: module.exports,
     React,
   };
-  vm.runInNewContext(code, sandbox, { filename: 'RepostButton.js' });
-  const { RepostButton } = module.exports;
-
   let renderer;
   await TestRenderer.act(async () => {
     renderer = TestRenderer.create(React.createElement(RepostButton, { target: '1' }));


### PR DESCRIPTION
## Summary
- break up src/nostr.tsx into smaller modules
- move auth helpers to `src/nostr/auth.tsx`
- move event helpers to `src/nostr/events.ts`
- move offline helpers to `src/nostr/offline.ts`
- update imports across app and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68860a4f4670833198d6e03fd3f97c56