### PR TITLE
Move discover logic to hook

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -12,8 +12,13 @@ import { Illustration } from './Illustration';
 
 
 export const Discover: React.FC = () => {
-  const { books: bookEvents, trending, newReleases, removeBook } =
-    useDiscoverBooks();
+  const {
+    books: bookEvents,
+    trending,
+    newReleases,
+    loading,
+    removeBook,
+  } = useDiscoverBooks();
   const { contacts } = useNostr();
   const [params, setParams] = useSearchParams();
   const [search, setSearch] = useState(params.get('q') || '');
@@ -116,7 +121,7 @@ export const Discover: React.FC = () => {
       <section className="p-[var(--space-4)]">
         <h2 className="mb-[var(--space-2)] font-semibold">Trending Books</h2>
         <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
-          {trending.length === 0
+          {loading && trending.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
               ))
@@ -132,7 +137,7 @@ export const Discover: React.FC = () => {
       <section className="p-[var(--space-4)]">
         <h2 className="mb-[var(--space-2)] font-semibold">New Releases</h2>
         <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
-          {newReleases.length === 0
+          {loading && newReleases.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
                 <BookCardSkeleton key={i} />
               ))
@@ -152,7 +157,7 @@ export const Discover: React.FC = () => {
             <div className="col-span-full">
               <Illustration text="No matching books found." />
             </div>
-          ) : recommended.length === 0 ? (
+          ) : loading && recommended.length === 0 ? (
             Array.from({ length: 6 }).map((_, i) => (
               <BookCardSkeleton key={i} />
             ))

--- a/test/useDiscoverBooks.test.js
+++ b/test/useDiscoverBooks.test.js
@@ -61,10 +61,14 @@ const path = require('path');
 
   await TestRenderer.act(async () => {
     TestRenderer.create(React.createElement(TestComp));
+  });
+  assert.strictEqual(result.loading, true);
+  await TestRenderer.act(async () => {
     await Promise.resolve();
     await Promise.resolve();
   });
-
+  assert.strictEqual(result.loading, false);
+  assert.strictEqual(result.books.length, 2);
   const trendIds = Array.from(result.trending, (b) => b.id);
   const newIds = Array.from(result.newReleases, (b) => b.id);
   assert.deepStrictEqual(trendIds, ['1', '2']);


### PR DESCRIPTION
## Summary
- update `useDiscoverBooks` usage in `Discover` component
- show skeletons only during loading
- expand unit test for hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d060f5cec8331a80bc917ba729caf