### PR TITLE
Refactor store access to use selectors

### DIFF
--- a/src/components/BookFeed.tsx
+++ b/src/components/BookFeed.tsx
@@ -3,10 +3,11 @@ import { useNostr } from '../nostr';
 import { BookCard } from './BookCard';
 import { BookCardSkeleton } from './BookCardSkeleton';
 import type { Event as NostrEvent } from 'nostr-tools';
-import { addEvent } from '../store/events';
+import { useEventStore } from '../store/events';
 
 export const BookFeed: React.FC = () => {
   const { subscribe } = useNostr();
+  const addEvent = useEventStore((s) => s.addEvent);
   const [events, setEvents] = useState<
     (NostrEvent & { repostedBy?: string })[]
   >([]);

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -3,7 +3,7 @@ import { useNostr } from '../nostr';
 import { DeleteButton } from './DeleteButton';
 import { ReportButton } from './ReportButton';
 import type { Event as NostrEvent } from 'nostr-tools';
-import { addEvent, addEvents } from '../store/events';
+import { useEventStore } from '../store/events';
 
 const PAGE_SIZE = 5;
 
@@ -19,6 +19,8 @@ export const Comments: React.FC<CommentsProps> = ({
   events: initialEvents,
 }) => {
   const { subscribe, publishComment, pubkey } = useNostr();
+  const addEvent = useEventStore((s) => s.addEvent);
+  const addEvents = useEventStore((s) => s.addEvents);
   const [events, setEvents] = useState<NostrEvent[]>(initialEvents ?? []);
   const [text, setText] = useState('');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -13,7 +13,10 @@ import { FaPen, FaTrophy } from 'react-icons/fa';
 
 export const Library: React.FC = () => {
   const { contacts } = useNostr();
-  const { books, finishBook, yearlyGoal, finishedCount } = useReadingStore();
+  const books = useReadingStore((s) => s.books);
+  const finishBook = useReadingStore((s) => s.finishBook);
+  const yearlyGoal = useReadingStore((s) => s.yearlyGoal);
+  const finishedCount = useReadingStore((s) => s.finishedCount);
   const navigate = useNavigate();
   const { unlocked } = useAchievements();
   const iconMap: Record<AchievementId, JSX.Element> = {

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FaAt, FaReply, FaUserPlus, FaBolt } from 'react-icons/fa';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { useNostr } from '../nostr';
-import { addEvent } from '../store/events';
+import { useEventStore } from '../store/events';
 
 type Notification = {
   id: string;
@@ -14,6 +14,7 @@ type Notification = {
 
 export const NotificationFeed: React.FC = () => {
   const { pubkey, subscribe } = useNostr();
+  const addEvent = useEventStore((s) => s.addEvent);
   const [items, setItems] = useState<Notification[]>([]);
 
   useEffect(() => {

--- a/src/components/ReaderModal.tsx
+++ b/src/components/ReaderModal.tsx
@@ -21,7 +21,8 @@ export const ReaderModal: React.FC<ReaderModalProps> = ({
   const [fontSize, setFontSize] = React.useState(16);
   const [percent, setPercent] = React.useState(0);
   const { theme, setTheme } = useTheme();
-  const { updateProgress, finishBook } = useReadingStore();
+  const updateProgress = useReadingStore((s) => s.updateProgress);
+  const finishBook = useReadingStore((s) => s.finishBook);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">

--- a/src/hooks/useDiscoverBooks.ts
+++ b/src/hooks/useDiscoverBooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
-import { addEvent } from '../store/events';
+import { useEventStore } from '../store/events';
 
 export interface DiscoverBook extends NostrEvent {
   repostedBy?: string;
@@ -17,6 +17,7 @@ export interface UseDiscoverBooksResult {
 
 export function useDiscoverBooks(): UseDiscoverBooksResult {
   const { subscribe, contacts } = useNostr();
+  const addEvent = useEventStore((s) => s.addEvent);
   const [events, setEvents] = useState<DiscoverBook[]>([]);
   const [votes, setVotes] = useState<Record<string, number>>({});
   const voteIds = useRef(new Set<string>());

--- a/src/screens/BookListScreen.tsx
+++ b/src/screens/BookListScreen.tsx
@@ -12,7 +12,7 @@ if (typeof window === 'undefined') {
 }
 import { useNavigate } from 'react-router-dom';
 import { useNostr } from '../nostr';
-import { addEvents } from '../store/events';
+import { useEventStore } from '../store/events';
 import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { BookPublishWizard } from '../components/BookPublishWizard';
 import { Button, Modal } from '../components/ui';
@@ -28,6 +28,7 @@ interface BookMeta {
 
 export const BookListScreen: React.FC = () => {
   const { subscribe, list, pubkey } = useNostr();
+  const addEvents = useEventStore((s) => s.addEvents);
   const [books, setBooks] = useState<BookMeta[]>([]);
   const [cursor, setCursor] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -4,7 +4,7 @@ import type { Event as NostrEvent, Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
 import { FollowButton } from '../components/FollowButton';
 import { BookCard } from '../components/BookCard';
-import { addEvent } from '../store/events';
+import { useEventStore } from '../store/events';
 
 interface ProfileMeta {
   name?: string;
@@ -14,6 +14,7 @@ interface ProfileMeta {
 
 export const ProfileScreen: React.FC = () => {
   const { pubkey: loggedPubkey, subscribe, list } = useNostr();
+  const addEvent = useEventStore((s) => s.addEvent);
   const params = useParams<{ pubkey?: string }>();
   const pubkey = params.pubkey || loggedPubkey;
 

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -15,7 +15,8 @@ export const ReaderScreen: React.FC = () => {
   const ctx = useNostr();
   const { subscribe } = ctx;
   const { theme, setTheme } = useTheme();
-  const { updateProgress, finishBook } = useReadingStore();
+  const updateProgress = useReadingStore((s) => s.updateProgress);
+  const finishBook = useReadingStore((s) => s.finishBook);
   const [title, setTitle] = React.useState('');
   const [html, setHtml] = React.useState('');
   const [percent, setPercent] = React.useState(0);

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand';
 import type { Event as NostrEvent } from 'nostr-tools';
 
+// Components should access store methods via selectors, e.g.
+// const addEvent = useEventStore(s => s.addEvent);
+
 function paramKey(evt: NostrEvent): string | null {
   const d = evt.tags.find((t) => t[0] === 'd')?.[1];
   if (d && evt.kind >= 30000 && evt.kind < 40000) {


### PR DESCRIPTION
## Summary
- use selector hooks instead of direct store access
- clarify usage in `src/store/events.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0a0cb1f0833186140c802dd1f2df