### PR TITLE
Fix react effects cleanup and deps

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -11,11 +11,25 @@ module.exports = [
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parser: parserTypeScript,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module', ecmaFeatures: { jsx: true } },
-      globals: { document: 'readonly', navigator: 'readonly', window: 'readonly' },
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        document: 'readonly',
+        navigator: 'readonly',
+        window: 'readonly',
+      },
     },
-    plugins: { '@typescript-eslint': pluginTypeScript, react: eslintPluginReact, 'react-hooks': eslintPluginReactHooks },
+    plugins: {
+      '@typescript-eslint': pluginTypeScript,
+      react: eslintPluginReact,
+      'react-hooks': eslintPluginReactHooks,
+    },
     settings: { react: { version: 'detect' } },
-    rules: {},
+    rules: {
+      'react-hooks/exhaustive-deps': 'error',
+    },
   },
 ];

--- a/src/components/ReaderView.tsx
+++ b/src/components/ReaderView.tsx
@@ -88,7 +88,7 @@ export const ReaderView: React.FC<ReaderViewProps> = ({
     };
     el.addEventListener('scroll', handle);
     return () => el.removeEventListener('scroll', handle);
-  }, [scrollSync, onPercentChange, onFinish]);
+  }, [scrollSync, onPercentChange, onFinish, bookId]);
 
   return (
     <div

--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -19,7 +19,7 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { buildCommentTags } from './commentUtils';
-import { getPrivKey, setPrivKey } from "./nostr/auth";
+import { getPrivKey, setPrivKey } from './nostr/auth';
 import {
   loadKey,
   importKey,
@@ -510,13 +510,14 @@ export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     if (!pubkey) return;
-    initOfflineSync({
+    const off = initOfflineSync({
       sendEvent,
       publish,
       list,
       pubkey,
     } as any);
-  }, [pubkey]);
+    return off;
+  }, [pubkey, sendEvent, publish, list]);
 
   const handleImportKey = () => {
     const input = prompt('Enter your private key');
@@ -593,5 +594,3 @@ export function useNostr() {
   if (!ctx) throw new Error('useNostr must be used within NostrProvider');
   return ctx;
 }
-
-


### PR DESCRIPTION
## Summary
- enforce `react-hooks/exhaustive-deps`
- return a cleanup function from `initOfflineSync`
- use returned cleanup in `nostr.tsx`
- include `bookId` in `ReaderView` scroll effect deps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0cfb674483318e1d31cfb674db05