### PR TITLE
Add logger and error handling

### DIFF
--- a/src/components/BookMetadataEditor.tsx
+++ b/src/components/BookMetadataEditor.tsx
@@ -3,6 +3,7 @@ import { useNostr } from '../nostr';
 import { publishBookMeta } from '../nostr/events';
 import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
+import { logError } from '../lib/logger';
 
 export interface BookMetadataEditorProps {
   bookId: string;
@@ -49,7 +50,8 @@ export const BookMetadataEditor: React.FC<BookMetadataEditorProps> = ({
       if (!navigator.onLine) throw new Error('offline');
       await publishBookMeta(ctx, bookId, data);
       onClose();
-    } catch {
+    } catch (err) {
+      logError(err);
       await queueOfflineEdit({
         id: Math.random().toString(36).slice(2),
         type: 'meta',

--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -5,6 +5,7 @@ import { publishLongPost, publishBookMeta } from '../nostr/events';
 import { useToast } from './ToastProvider';
 import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';
+import { logError } from '../lib/logger';
 
 export interface BookPublishWizardProps {
   onPublish?: (id: string) => void;
@@ -75,7 +76,8 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
       toast(
         `Book published! <a href="/book/${evt.id}">View book</a>`,
       );
-    } catch {
+    } catch (err) {
+      logError(err);
       toast('Failed to publish book.');
     } finally {
       setPublishing(false);

--- a/src/components/ChapterEditorModal.tsx
+++ b/src/components/ChapterEditorModal.tsx
@@ -3,6 +3,7 @@ import { useNostr } from '../nostr';
 import { publishLongPost } from '../nostr/events';
 import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
+import { logError } from '../lib/logger';
 
 interface Props {
   bookId: string;
@@ -82,7 +83,8 @@ export const ChapterEditorModal: React.FC<Props> = ({
           body: JSON.stringify(evt),
         });
       }
-    } catch {
+    } catch (err) {
+      logError(err);
       await queueOfflineEdit({
         id: Math.random().toString(36).slice(2),
         type: 'chapter',

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FaTrash } from 'react-icons/fa';
 import { useNostr } from '../nostr';
 import { useToast } from './ToastProvider';
+import { logError } from '../lib/logger';
 
 export interface DeleteButtonProps {
   target: string;
@@ -21,7 +22,8 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     try {
       await publish({ kind: 5, content: '', tags: [['e', target]] });
       onDelete?.();
-    } catch {
+    } catch (err) {
+      logError(err);
       toast('Action failed', { type: 'error' });
     }
   };

--- a/src/components/ReactionButton.tsx
+++ b/src/components/ReactionButton.tsx
@@ -4,6 +4,7 @@ import { useNostr } from '../nostr';
 import { publishVote, publishFavourite } from '../nostr/events';
 import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
+import { logError } from '../lib/logger';
 import type { Event as NostrEvent } from 'nostr-tools';
 
 export interface ReactionButtonProps {
@@ -58,7 +59,8 @@ export const ReactionButton: React.FC<ReactionButtonProps> = ({
         await publishFavourite(ctx, target);
       }
       setActive(true);
-    } catch {
+    } catch (err) {
+      logError(err);
       toast('Action failed', { type: 'error' });
     }
   };

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -4,6 +4,7 @@ import { useNostr } from '../nostr';
 import { publishRepost } from '../nostr/events';
 import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
+import { logError } from '../lib/logger';
 
 export interface RepostButtonProps {
   target: string;
@@ -29,7 +30,8 @@ export const RepostButton: React.FC<RepostButtonProps> = ({
         return;
       }
       await publishRepost(ctx, target);
-    } catch {
+    } catch (err) {
+      logError(err);
       toast('Action failed', { type: 'error' });
     }
   };

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,12 @@
+export function logError(err: unknown): void {
+  console.error(err);
+  try {
+    const { logEvent } = require('../analytics');
+    if (logEvent) {
+      const message = err instanceof Error ? err.message : String(err);
+      logEvent('error', { message });
+    }
+  } catch {
+    /* ignore analytics errors */
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple console/analytics logger
- log errors when toast notifications fire

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d0f2f81dc83318d6cd778be545128