### PR TITLE
Add focus ring and axe test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 3000"
+    "preview": "vite preview --port 3000",
+    "test:axe": "jest test/accessibility.test.tsx"
   },
   "keywords": [],
   "author": "",
@@ -36,7 +37,11 @@
     "esbuild": "^0.25.8",
     "typescript": "^5.8.3",
     "vite": "^5.2.0",
-    "vite-plugin-pwa": "^1.0.2"
+    "vite-plugin-pwa": "^1.0.2",
+    "jest": "^30.0.5",
+    "jest-axe": "^7.1.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -32,7 +32,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Delete"
-      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-600/50 ${className ?? ''}`}
     >
       <FaTrash aria-hidden="true" />
     </button>

--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -28,7 +28,7 @@ export const ReportButton: React.FC<ReportButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Report"
-      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-600/50 ${className ?? ''}`}
     >
       <FaFlag aria-hidden="true" />
     </button>

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -40,7 +40,7 @@ export const RepostButton: React.FC<RepostButtonProps> = ({
     <button
       onClick={handleClick}
       aria-label="Repost"
-      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] ${className ?? ''}`}
+      className={`rounded-[var(--radius-button)] border px-[var(--space-2)] py-[var(--space-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-600/50 ${className ?? ''}`}
     >
       <FaRetweet aria-hidden="true" />
     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -61,3 +61,12 @@ html {
 .card-hover {
   @apply transition-shadow duration-150 ease-in-out hover:[box-shadow:var(--shadow-1)];
 }
+
+button:focus-visible,
+[role="button"]:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  @apply outline-none ring-2 ring-offset-2 ring-primary-600/50;
+}

--- a/test/accessibility.test.tsx
+++ b/test/accessibility.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import AboutPage from '../src/pages/About';
+
+expect.extend(toHaveNoViolations);
+
+test('About page has no accessibility violations', async () => {
+  const { container } = render(<AboutPage />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});


### PR DESCRIPTION
## Summary
- add global focus-visible ring styles for interactive elements
- ensure icon buttons have focus rings
- add jest axe test for About page
- add jest & testing dependencies

## Testing
- `npm test`
- `npm run test:axe` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d10ed070c83319504d5d89c84b587