### PR TITLE
Fix grey text contrast

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -61,7 +61,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
   return (
     <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
       {event.repostedBy && (
-        <p className="mb-[var(--space-1)] text-xs text-gray-500">
+        <p className="mb-[var(--space-1)] text-xs text-text-muted">
           Reposted by {event.repostedBy}
         </p>
       )}
@@ -73,7 +73,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         />
       )}
       <h3 className="font-semibold">{title}</h3>
-      {summary && <p className="text-sm text-gray-500">{summary}</p>}
+      {summary && <p className="text-sm text-text-muted">{summary}</p>}
       {attachments.map((a) => (
         <a
           key={a.id}

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -94,7 +94,7 @@ export const Comments: React.FC<CommentsProps> = ({
   return (
     <div className={`${parentEventId ? 'ml-4' : ''} space-y-2`}>
       {replies.length === 0 && !parentEventId && (
-        <p className="text-gray-500">No comments yet – be the first to reply!</p>
+        <p className="text-text-muted">No comments yet – be the first to reply!</p>
       )}
       {visibleReplies.map((c) => (
         <CommentItem key={c.id} comment={c} />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -7,7 +7,7 @@ const AboutPage: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <div className="space-y-1 text-sm text-gray-600">
+      <div className="space-y-1 text-sm text-text-muted">
         <p>Version: {version}</p>
         <p>Commit: {sha}</p>
         <p>Built: {buildDate}</p>

--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -168,7 +168,7 @@ export const ProfileSettingsPage: React.FC = () => {
           )}
           <div className="flex-1 space-y-1">
             <h3 className="font-semibold">{form.name || pubkey}</h3>
-            {form.about && <p className="text-sm text-gray-600">{form.about}</p>}
+            {form.about && <p className="text-sm text-text-muted">{form.about}</p>}
           </div>
         </div>
       </div>

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -72,8 +72,8 @@ export const ProfileScreen: React.FC = () => {
         )}
         <div className="flex-1 space-y-1">
           <h2 className="text-xl font-semibold">{meta?.name || pubkey}</h2>
-          {meta?.about && <p className="text-sm text-gray-600">{meta.about}</p>}
-          <p className="text-sm text-gray-600">{followers} followers</p>
+          {meta?.about && <p className="text-sm text-text-muted">{meta.about}</p>}
+          <p className="text-sm text-text-muted">{followers} followers</p>
         </div>
         {pubkey !== loggedPubkey && <FollowButton pubkey={pubkey} />}
       </div>


### PR DESCRIPTION
## Summary
- replace grey utility classes with `text-text-muted`
- keep grey background styles for toasts
- update a few page components to use the new colour

## Testing
- `npm run lint` *(fails: React Hook useEffect has missing dependency)*
- `npm test`
- `npm run test:axe`


------
https://chatgpt.com/codex/tasks/task_e_688d16a1ec248331a7672ed0a9a67081