### PR TITLE
Improve card list semantics

### DIFF
--- a/src/components/BookFeed.tsx
+++ b/src/components/BookFeed.tsx
@@ -44,18 +44,23 @@ export const BookFeed: React.FC = () => {
   }, [subscribe]);
 
   return (
-    <div className="space-y-4">
+    <ul role="list" className="space-y-4">
       {events.length === 0
-        ? Array.from({ length: 3 }).map((_, i) => <BookCardSkeleton key={i} />)
+        ? Array.from({ length: 3 }).map((_, i) => (
+            <li key={i} role="listitem">
+              <BookCardSkeleton />
+            </li>
+          ))
         : events.map((e) => (
-            <BookCard
-              key={e.id}
-              event={e}
-              onDelete={(id) =>
-                setEvents((evts) => evts.filter((x) => x.id !== id))
-              }
-            />
+            <li key={e.id} role="listitem">
+              <BookCard
+                event={e}
+                onDelete={(id) =>
+                  setEvents((evts) => evts.filter((x) => x.id !== id))
+                }
+              />
+            </li>
           ))}
-    </div>
+    </ul>
   );
 };

--- a/src/components/BookHistory.tsx
+++ b/src/components/BookHistory.tsx
@@ -7,7 +7,10 @@ export interface BookHistoryProps {
   onClose?: () => void;
 }
 
-export const BookHistory: React.FC<BookHistoryProps> = ({ bookId, onClose }) => {
+export const BookHistory: React.FC<BookHistoryProps> = ({
+  bookId,
+  onClose,
+}) => {
   const { list, publish } = useNostr();
   const [events, setEvents] = useState<NostrEvent[]>([]);
   const [openId, setOpenId] = useState<string | null>(null);
@@ -40,9 +43,13 @@ export const BookHistory: React.FC<BookHistoryProps> = ({ bookId, onClose }) => 
             </button>
           )}
         </div>
-        <div className="space-y-2">
+        <ul role="list" className="space-y-2">
           {events.map((e) => (
-            <div key={e.id} className="space-y-2 rounded border p-2">
+            <li
+              key={e.id}
+              role="listitem"
+              className="space-y-2 rounded border p-2"
+            >
               <div className="flex items-center justify-between gap-2">
                 <span>{new Date(e.created_at * 1000).toLocaleString()}</span>
                 <div className="flex gap-2">
@@ -65,9 +72,9 @@ export const BookHistory: React.FC<BookHistoryProps> = ({ bookId, onClose }) => 
                   {e.content || JSON.stringify(e.tags)}
                 </pre>
               )}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </div>
   );

--- a/src/components/CommunityFeed.tsx
+++ b/src/components/CommunityFeed.tsx
@@ -17,16 +17,16 @@ export const CommunityFeed: React.FC = () => {
   }, [subscribe]);
 
   return (
-    <div className="space-y-4">
+    <ul role="list" className="space-y-4">
       {events.map((evt) => {
         const name = evt.tags.find((t) => t[0] === 'name')?.[1] || 'Unnamed';
         return (
-          <div key={evt.id} className="rounded border p-2">
+          <li key={evt.id} role="listitem" className="rounded border p-2">
             <h3 className="font-semibold">{name}</h3>
             <p className="text-sm whitespace-pre-wrap">{evt.content}</p>
-          </div>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 };

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -10,7 +10,6 @@ import { logEvent } from '../analytics';
 import { CommunityFeed } from './CommunityFeed';
 import { Illustration } from './Illustration';
 
-
 export const Discover: React.FC = () => {
   const {
     books: bookEvents,
@@ -120,57 +119,77 @@ export const Discover: React.FC = () => {
       </div>
       <section className="p-[var(--space-4)]">
         <h2 className="mb-[var(--space-2)] font-semibold">Trending Books</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
+        <ul
+          role="list"
+          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+        >
           {loading && trending.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
-                <BookCardSkeleton key={i} />
+                <li key={i} role="listitem">
+                  <BookCardSkeleton />
+                </li>
               ))
             : trending.map((e) => (
-                <BookCard
-                  key={e.id}
-                  event={e as NostrEvent}
-                  onDelete={(id) => removeBook(id)}
-                />
+                <li key={e.id} role="listitem">
+                  <BookCard
+                    event={e as NostrEvent}
+                    onDelete={(id) => removeBook(id)}
+                  />
+                </li>
               ))}
-        </div>
+        </ul>
       </section>
       <section className="p-[var(--space-4)]">
         <h2 className="mb-[var(--space-2)] font-semibold">New Releases</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
+        <ul
+          role="list"
+          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+        >
           {loading && newReleases.length === 0
             ? Array.from({ length: 6 }).map((_, i) => (
-                <BookCardSkeleton key={i} />
+                <li key={i} role="listitem">
+                  <BookCardSkeleton />
+                </li>
               ))
             : newReleases.map((e) => (
-                <BookCard
-                  key={e.id}
-                  event={e as NostrEvent}
-                  onDelete={(id) => removeBook(id)}
-                />
+                <li key={e.id} role="listitem">
+                  <BookCard
+                    event={e as NostrEvent}
+                    onDelete={(id) => removeBook(id)}
+                  />
+                </li>
               ))}
-        </div>
+        </ul>
       </section>
       <section className="p-[var(--space-4)]">
-        <h2 className="mb-[var(--space-2)] font-semibold">Recommended for You</h2>
-        <div className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4">
+        <h2 className="mb-[var(--space-2)] font-semibold">
+          Recommended for You
+        </h2>
+        <ul
+          role="list"
+          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+        >
           {noResults ? (
             <div className="col-span-full">
               <Illustration text="No matching books found." />
             </div>
           ) : loading && recommended.length === 0 ? (
             Array.from({ length: 6 }).map((_, i) => (
-              <BookCardSkeleton key={i} />
+              <li key={i} role="listitem">
+                <BookCardSkeleton />
+              </li>
             ))
           ) : (
             recommended.map((e) => (
-              <BookCard
-                key={e.id}
-                event={e as NostrEvent}
-                onDelete={(id) => removeBook(id)}
-              />
+              <li key={e.id} role="listitem">
+                <BookCard
+                  event={e as NostrEvent}
+                  onDelete={(id) => removeBook(id)}
+                />
+              </li>
             ))
           )}
-        </div>
+        </ul>
       </section>
       <section className="p-[var(--space-4)]">
         <h2 className="mb-[var(--space-2)] font-semibold">Communities</h2>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -39,7 +39,9 @@ export const Library: React.FC = () => {
         className="flex items-center justify-between"
         style={{ height: 56 }}
       >
-        <h1 className="text-[20px] font-bold text-[color:var(--clr-primary-600)]">Bookstr</h1>
+        <h1 className="text-[20px] font-bold text-[color:var(--clr-primary-600)]">
+          Bookstr
+        </h1>
         <OnboardingTooltip
           storageKey="library-settings"
           text="Library settings"
@@ -58,7 +60,7 @@ export const Library: React.FC = () => {
           <button
             key={t.key}
             onClick={() => setTab(t.key)}
-              className={`pb-[var(--space-1)] text-[14px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-600/50 ${tab === t.key ? 'border-b-2 border-[color:var(--clr-primary-600)] text-[color:var(--clr-text)]' : 'text-text-muted'}`}
+            className={`pb-[var(--space-1)] text-[14px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-600/50 ${tab === t.key ? 'border-b-2 border-[color:var(--clr-primary-600)] text-[color:var(--clr-text)]' : 'text-text-muted'}`}
           >
             {t.label}
           </button>
@@ -85,7 +87,7 @@ export const Library: React.FC = () => {
           ))}
         </div>
       )}
-      <div className="mt-[var(--space-4)] space-y-2">
+      <ul role="list" className="mt-[var(--space-4)] space-y-2">
         {books
           .filter((item) => {
             if (tab === 'following') {
@@ -94,14 +96,15 @@ export const Library: React.FC = () => {
             return item.status === tab;
           })
           .map((item) => (
-            <div
+            <li
               key={item.id}
-                className="mb-[var(--space-2)] flex items-center gap-4 rounded-card bg-border p-[var(--space-3)]"
+              role="listitem"
+              className="mb-[var(--space-2)] flex items-center gap-4 rounded-card bg-border p-[var(--space-3)]"
             >
               <img
                 src={item.cover}
                 alt={`Cover image for ${item.title}`}
-                  className="h-[84px] w-[56px] rounded object-cover"
+                className="h-[84px] w-[56px] rounded object-cover"
               />
               <div className="flex-1 space-y-1">
                 <h3 className="text-[16px] font-semibold leading-6">
@@ -110,7 +113,7 @@ export const Library: React.FC = () => {
                 <p className="text-[14px] leading-5 text-text-muted">
                   {item.author}
                 </p>
-                  <span className="inline-block rounded bg-[color:var(--clr-surface-alt)] px-[var(--space-2)] py-[2px] text-[12px] text-text-muted">
+                <span className="inline-block rounded bg-[color:var(--clr-surface-alt)] px-[var(--space-2)] py-[2px] text-[12px] text-text-muted">
                   {item.genre}
                 </span>
                 <div className="mt-[var(--space-1)] h-1 rounded bg-border">
@@ -129,9 +132,9 @@ export const Library: React.FC = () => {
                 </button>
                 <span>{item.percent}%</span>
               </div>
-            </div>
+            </li>
           ))}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -84,9 +84,13 @@ export const NotificationFeed: React.FC = () => {
   } as const;
 
   return (
-    <div className="space-y-2">
+    <ul role="list" className="space-y-2">
       {items.map((n) => (
-        <div key={n.id} className="flex items-center gap-2 rounded border p-2">
+        <li
+          key={n.id}
+          role="listitem"
+          className="flex items-center gap-2 rounded border p-2"
+        >
           <span>{iconMap[n.type]}</span>
           {n.link ? (
             <Link to={n.link} className="text-blue-600 underline">
@@ -109,8 +113,8 @@ export const NotificationFeed: React.FC = () => {
                     : 'Mentioned you'}
             </span>
           )}
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -63,10 +63,16 @@ html {
 }
 
 button:focus-visible,
-[role="button"]:focus-visible,
+[role='button']:focus-visible,
 a:focus-visible,
 input:focus-visible,
 textarea:focus-visible,
 select:focus-visible {
   @apply outline-none ring-2 ring-offset-2 ring-primary-600/50;
+}
+
+ul[role='list'] {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -72,19 +72,23 @@ export const ProfileScreen: React.FC = () => {
         )}
         <div className="flex-1 space-y-1">
           <h2 className="text-xl font-semibold">{meta?.name || pubkey}</h2>
-          {meta?.about && <p className="text-sm text-text-muted">{meta.about}</p>}
+          {meta?.about && (
+            <p className="text-sm text-text-muted">{meta.about}</p>
+          )}
           <p className="text-sm text-text-muted">{followers} followers</p>
         </div>
         {pubkey !== loggedPubkey && <FollowButton pubkey={pubkey} />}
       </div>
-      <div className="space-y-2">
+      <ul role="list" className="space-y-2">
         {books.map((evt) => (
-          <BookCard key={evt.id} event={evt} />
+          <li key={evt.id} role="listitem">
+            <BookCard event={evt} />
+          </li>
         ))}
         {books.length === 0 && (
           <p className="text-center text-text-muted">No books found.</p>
         )}
-      </div>
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- apply `ul`/`li` semantics to card collections
- remove default list markers with CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d183801fc8331955337d636a83cdf