### PR TITLE
Implement events SW caching

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -34,6 +34,16 @@ registerRoute(
   new StaleWhileRevalidate({ cacheName: 'api' }),
 );
 
+// Cache event list responses separately so they can be reused while a
+// background refresh runs. This applies to both API endpoints and relay
+// HTTP gateways.
+registerRoute(
+  ({ request, url }) =>
+    request.method === 'GET' &&
+    (url.pathname.startsWith(`${API_BASE}/event`) || /relay/i.test(url.hostname)),
+  new StaleWhileRevalidate({ cacheName: 'events' }),
+);
+
 const bgSync = new BackgroundSyncPlugin('actions', {
   maxRetentionTime: 24 * 60,
 });

--- a/test/registerSw.test.js
+++ b/test/registerSw.test.js
@@ -13,5 +13,10 @@ const { registerServiceWorker } = require('../src/registerSw');
   delete navigator.serviceWorker;
   registerServiceWorker();
 
+  const fs = require('fs');
+  const path = require('path');
+  const swSrc = fs.readFileSync(path.join(__dirname, '../src/sw.ts'), 'utf8');
+  assert(swSrc.includes("cacheName: 'events'"), 'events cache route missing');
+
   console.log('All tests passed.');
 })();


### PR DESCRIPTION
## Summary
- add stale-while-revalidate caching for event list requests
- check service worker for events cache route in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d1f8be5148331b6c8e74fd539a307