### PR TITLE
Add Jest RTL snapshot tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -12,4 +12,9 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  setupFilesAfterEnv: ['<rootDir>/test/jest/setupTests.ts'],
+  testMatch: [
+    '<rootDir>/test/jest/**/*.test.tsx',
+    '<rootDir>/test/accessibility.test.tsx',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 3000",
-    "test:axe": "jest test/accessibility.test.tsx"
+    "test:axe": "jest test/accessibility.test.tsx",
+    "test:rtl": "jest"
   },
   "keywords": [],
   "author": "",

--- a/test/jest/BookPublishWizard.test.tsx
+++ b/test/jest/BookPublishWizard.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BookPublishWizard } from '../../src/components/BookPublishWizard';
+
+jest.mock('../../src/nostr', () => ({
+  useNostr: () => ({ publish: jest.fn() }),
+}));
+
+jest.mock('../../src/components/ToastProvider', () => ({
+  useToast: () => jest.fn(),
+}));
+
+describe('BookPublishWizard', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<BookPublishWizard />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/test/jest/Discover.test.tsx
+++ b/test/jest/Discover.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Discover } from '../../src/components/Discover';
+
+jest.mock('../../src/analytics', () => ({ logEvent: jest.fn() }));
+
+jest.mock('../../src/nostr', () => ({
+  useNostr: () => ({ contacts: [], subscribe: jest.fn() }),
+}));
+
+jest.mock('../../src/hooks/useDiscoverBooks', () => ({
+  useDiscoverBooks: () => ({
+    books: [],
+    trending: [],
+    newReleases: [],
+    loading: false,
+    removeBook: jest.fn(),
+  }),
+}));
+
+describe('Discover', () => {
+  it('mobile snapshot', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 375 });
+    window.dispatchEvent(new Event('resize'));
+    const { container } = render(
+      <MemoryRouter>
+        <Discover />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('desktop snapshot', () => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1200 });
+    window.dispatchEvent(new Event('resize'));
+    const { container } = render(
+      <MemoryRouter>
+        <Discover />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/test/jest/LoginModal.test.tsx
+++ b/test/jest/LoginModal.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LoginModal } from '../../src/components/LoginModal';
+
+jest.mock('../../src/nostr', () => ({
+  useNostr: () => ({
+    login: jest.fn(),
+    logout: jest.fn(),
+    loginNip07: jest.fn(),
+    pubkey: null,
+  }),
+}));
+
+jest.mock('../../src/nostr/auth', () => ({
+  connectNostrWallet: jest.fn(),
+  nostrLogin: jest.fn(),
+}));
+
+describe('LoginModal', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<LoginModal onClose={() => {}} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/test/jest/__snapshots__/BookPublishWizard.test.tsx.snap
+++ b/test/jest/__snapshots__/BookPublishWizard.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`BookPublishWizard matches snapshot 1`] = `
+<div
+  class="space-y-4"
+>
+  <div
+    class="space-y-2"
+  >
+    <input
+      class="w-full rounded border p-[var(--space-2)]"
+      placeholder="Title"
+      value=""
+    />
+    <textarea
+      class="w-full rounded border p-2"
+      placeholder="Summary"
+    />
+    <button
+      class="rounded bg-[color:var(--clr-primary-600)] px-[var(--space-4)] py-[var(--space-2)] text-white"
+    >
+      Next
+    </button>
+  </div>
+</div>
+`;

--- a/test/jest/__snapshots__/Discover.test.tsx.snap
+++ b/test/jest/__snapshots__/Discover.test.tsx.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Discover desktop snapshot 1`] = `
+<div
+  class="pb-[var(--space-4)]"
+>
+  <header
+    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)]"
+  >
+    <h1
+      class="text-[18px] font-semibold text-white"
+    >
+      Bookstr
+    </h1>
+    <div
+      class="flex flex-1 items-center gap-1 relative rounded ring-2 ring-primary-300"
+    >
+      <input
+        class="w-full rounded-[var(--radius-button)] border border-border p-[var(--space-2)] bg-[color:var(--clr-surface)] text-[color:var(--clr-text)] focus-visible:outline-none focus-visible:[box-shadow:var(--focus-ring)]"
+        placeholder="Search"
+        value=""
+      />
+      <div
+        class="pointer-events-none absolute z-10 mt-[var(--space-1)] whitespace-nowrap rounded bg-primary-600 px-2 py-1 text-[12px] text-white shadow"
+      >
+        Search for books
+      </div>
+    </div>
+  </header>
+  <div
+    class="flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+  >
+    <button
+      aria-label="All"
+      aria-pressed="true"
+      class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+    >
+      All
+    </button>
+  </div>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Trending Books
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      New Releases
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Recommended for You
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Communities
+    </h2>
+    <ul
+      class="space-y-4"
+      role="list"
+    />
+  </section>
+</div>
+`;
+
+exports[`Discover mobile snapshot 1`] = `
+<div
+  class="pb-[var(--space-4)]"
+>
+  <header
+    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)]"
+  >
+    <h1
+      class="text-[18px] font-semibold text-white"
+    >
+      Bookstr
+    </h1>
+    <div
+      class="flex flex-1 items-center gap-1 relative rounded ring-2 ring-primary-300"
+    >
+      <input
+        class="w-full rounded-[var(--radius-button)] border border-border p-[var(--space-2)] bg-[color:var(--clr-surface)] text-[color:var(--clr-text)] focus-visible:outline-none focus-visible:[box-shadow:var(--focus-ring)]"
+        placeholder="Search"
+        value=""
+      />
+      <div
+        class="pointer-events-none absolute z-10 mt-[var(--space-1)] whitespace-nowrap rounded bg-primary-600 px-2 py-1 text-[12px] text-white shadow"
+      >
+        Search for books
+      </div>
+    </div>
+  </header>
+  <div
+    class="flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+  >
+    <button
+      aria-label="All"
+      aria-pressed="true"
+      class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+    >
+      All
+    </button>
+  </div>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Trending Books
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      New Releases
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Recommended for You
+    </h2>
+    <ul
+      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+      role="list"
+    />
+  </section>
+  <section
+    class="p-[var(--space-4)]"
+  >
+    <h2
+      class="mb-[var(--space-2)] font-semibold"
+    >
+      Communities
+    </h2>
+    <ul
+      class="space-y-4"
+      role="list"
+    />
+  </section>
+</div>
+`;

--- a/test/jest/__snapshots__/LoginModal.test.tsx.snap
+++ b/test/jest/__snapshots__/LoginModal.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`LoginModal matches snapshot 1`] = `
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-[var(--space-2)]"
+>
+  <div
+    class="w-full max-w-sm space-y-4 rounded bg-[color:var(--clr-surface)] p-[var(--space-4)]"
+  >
+    <div
+      class="flex gap-2"
+    >
+      <button
+        class="flex-1 rounded border px-[var(--space-2)] py-[var(--space-1)] bg-border"
+      >
+        Private Key
+      </button>
+      <button
+        class="flex-1 rounded border px-[var(--space-2)] py-[var(--space-1)] "
+      >
+        NIP-07
+      </button>
+      <button
+        class="flex-1 rounded border px-[var(--space-2)] py-[var(--space-1)] "
+      >
+        Remote
+      </button>
+    </div>
+    <div
+      class="space-y-2"
+    >
+      <input
+        class="w-full rounded border p-[var(--space-2)]"
+        placeholder="nsec or hex"
+        value=""
+      />
+      <button
+        class="w-full rounded bg-[color:var(--clr-primary-600)] px-[var(--space-3)] py-[var(--space-1)] text-white disabled:opacity-50"
+        disabled=""
+      >
+        Login
+      </button>
+    </div>
+    <div
+      class="flex justify-end"
+    >
+      <button
+        class="rounded px-[var(--space-3)] py-[var(--space-1)] border"
+      >
+        Close
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/test/jest/setupTests.ts
+++ b/test/jest/setupTests.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- configure Jest for RTL tests
- add Jest script
- create setupTests for RTL
- snapshot tests for LoginModal, Discover, and BookPublishWizard

## Testing
- `npm run test:axe`
- `npm run test:rtl`


------
https://chatgpt.com/codex/tasks/task_e_688d22d408c48331b596679af5306a98