### PR TITLE
Add private key visibility toggle

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -12,7 +12,7 @@ export const Login: React.FC = () => {
       login(priv);
       setError(null);
     } catch {
-      setError('Invalid private key');
+      setError('Invalid private key (64-char hex or nsec)');
     }
   };
 

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -30,7 +30,7 @@ export const LoginButton: React.FC = () => {
       login(priv);
       setError(null);
     } catch {
-      setError('Invalid private key');
+      setError('Invalid private key (64-char hex or nsec)');
     }
   };
 

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -14,6 +14,7 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
   const [tab, setTab] = React.useState<'priv' | 'nip07' | 'remote'>('priv');
 
   const [privInput, setPrivInput] = React.useState('');
+  const [showPriv, setShowPriv] = React.useState(false);
   const [privError, setPrivError] = React.useState<string | null>(null);
 
   const [remoteUrl, setRemoteUrl] = React.useState('');
@@ -38,7 +39,7 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
   const handlePrivLogin = () => {
     const key = importKey(privInput);
     if (!key || !validatePrivKey(key)) {
-      setPrivError('Invalid private key');
+      setPrivError('Invalid private key (64-char hex or nsec)');
       return;
     }
     try {
@@ -46,7 +47,7 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
       setPrivError(null);
       onClose();
     } catch {
-      setPrivError('Invalid private key');
+      setPrivError('Invalid private key (64-char hex or nsec)');
     }
   };
 
@@ -136,12 +137,23 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
         </div>
         {tab === 'priv' && (
           <div className="space-y-2">
-            <input
-              value={privInput}
-              onChange={(e) => setPrivInput(e.target.value)}
-              placeholder="nsec or hex"
-              className="w-full rounded border p-[var(--space-2)]"
-            />
+            <div className="flex gap-2">
+              <input
+                type={showPriv ? 'text' : 'password'}
+                value={privInput}
+                onChange={(e) => setPrivInput(e.target.value)}
+                placeholder="nsec or hex"
+                className="flex-1 rounded border p-[var(--space-2)]"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPriv((v) => !v)}
+                aria-label={showPriv ? 'Hide private key' : 'Show private key'}
+                className="rounded border px-[var(--space-2)]"
+              >
+                {showPriv ? 'Hide' : 'Show'}
+              </button>
+            </div>
             {privError && <p className="text-red-600 text-sm">{privError}</p>}
             <button
               onClick={handlePrivLogin}

--- a/test/bookDetailAuthorFilter.test.js
+++ b/test/bookDetailAuthorFilter.test.js
@@ -50,6 +50,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookDetailScreen.js' });

--- a/test/bookDetailScreen.test.js
+++ b/test/bookDetailScreen.test.js
@@ -37,6 +37,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookDetailScreen.js' });

--- a/test/bookHistory.test.js
+++ b/test/bookHistory.test.js
@@ -35,6 +35,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookHistory.js' });

--- a/test/bookListScreen.test.js
+++ b/test/bookListScreen.test.js
@@ -28,6 +28,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookListScreen.js' });
   const { BookListScreen } = module.exports;

--- a/test/bookPublishMeta.test.js
+++ b/test/bookPublishMeta.test.js
@@ -51,6 +51,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookPublishWizard.js' });

--- a/test/bookPublishToast.test.js
+++ b/test/bookPublishToast.test.js
@@ -47,6 +47,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'BookPublishWizard.js' });

--- a/test/chapterEditorModalAuth.test.js
+++ b/test/chapterEditorModalAuth.test.js
@@ -38,6 +38,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'ChapterEditorModal.js' });

--- a/test/commentsPlaceholder.test.js
+++ b/test/commentsPlaceholder.test.js
@@ -33,6 +33,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'Comments.js' });

--- a/test/deleteButtonToast.test.js
+++ b/test/deleteButtonToast.test.js
@@ -39,6 +39,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'DeleteButton.js' });

--- a/test/discoverGridLayout.test.js
+++ b/test/discoverGridLayout.test.js
@@ -30,7 +30,7 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
-        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [] }) };
+        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [], relays: [] }) };
       }
       if (p.endsWith('BookCard') || p.endsWith('BookCard.tsx')) {
         return { BookCard: () => React.createElement('div') };
@@ -52,6 +52,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'Discover.js' });

--- a/test/discoverSearchNoMatch.test.js
+++ b/test/discoverSearchNoMatch.test.js
@@ -30,7 +30,7 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
-        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [] }) };
+        return { useNostr: () => ({ subscribe: () => () => {}, contacts: [], relays: [] }) };
       }
       if (p.endsWith('BookCard') || p.endsWith('BookCard.tsx')) {
         return { BookCard: () => React.createElement('div') };
@@ -52,6 +52,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'Discover.js' });

--- a/test/jest/__snapshots__/LoginModal.test.tsx.snap
+++ b/test/jest/__snapshots__/LoginModal.test.tsx.snap
@@ -29,11 +29,23 @@ exports[`LoginModal matches snapshot 1`] = `
     <div
       class="space-y-2"
     >
-      <input
-        class="w-full rounded border p-[var(--space-2)]"
-        placeholder="nsec or hex"
-        value=""
-      />
+      <div
+        class="flex gap-2"
+      >
+        <input
+          class="flex-1 rounded border p-[var(--space-2)]"
+          placeholder="nsec or hex"
+          type="password"
+          value=""
+        />
+        <button
+          aria-label="Show private key"
+          class="rounded border px-[var(--space-2)]"
+          type="button"
+        >
+          Show
+        </button>
+      </div>
       <button
         class="w-full rounded bg-[color:var(--clr-primary-600)] px-[var(--space-3)] py-[var(--space-1)] text-white disabled:opacity-50"
         disabled=""

--- a/test/reactionButtonToast.test.js
+++ b/test/reactionButtonToast.test.js
@@ -46,6 +46,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'ReactionButton.js' });

--- a/test/repostButtonToast.test.js
+++ b/test/repostButtonToast.test.js
@@ -42,6 +42,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'RepostButton.js' });

--- a/test/settings/manageChapters.spec.tsx
+++ b/test/settings/manageChapters.spec.tsx
@@ -62,6 +62,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
     fetch: async (_u, opts) => { published = JSON.parse(opts.body); return { ok: true }; },
   };

--- a/test/settings/offline.spec.tsx
+++ b/test/settings/offline.spec.tsx
@@ -35,6 +35,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'OfflineSettingsPage.js' });

--- a/test/settings/profile.spec.tsx
+++ b/test/settings/profile.spec.tsx
@@ -42,6 +42,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
     fetch: async (url, opts) => { saved = JSON.parse(opts.body); return { ok: true }; },
   };

--- a/test/settings/ui.spec.tsx
+++ b/test/settings/ui.spec.tsx
@@ -25,6 +25,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
   };
   vm.runInNewContext(code, sandbox, { filename: 'UISettingsPage.js' });

--- a/test/useDiscoverBooks.test.js
+++ b/test/useDiscoverBooks.test.js
@@ -23,6 +23,7 @@ const path = require('path');
         return {
           useNostr: () => ({
             contacts: [],
+            relays: [],
             subscribe: (filters, cb) => {
               const kinds = (filters[0].kinds || []);
               if (kinds.includes(30023)) {
@@ -47,6 +48,7 @@ const path = require('path');
     module,
     exports: module.exports,
     TextEncoder,
+    TextDecoder,
     React,
     process,
   };


### PR DESCRIPTION
## Summary
- show/hide toggle for private key input
- clarify private key validation messages
- adjust tests for new login modal markup and TextDecoder requirement

## Testing
- `npm test` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_e_688d2826ff3883319a903c7c5499a2a4