### PR TITLE
Improve suggestions keyboard a11y

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,16 +35,21 @@ export const Header: React.FC<HeaderProps> = ({
     if (!suggestions || suggestions.length === 0) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setActive((a) => (a + 1) % suggestions.length);
+      setActive((a) => Math.min(a + 1, suggestions.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setActive((a) => (a - 1 + suggestions.length) % suggestions.length);
+      setActive((a) => Math.max(0, a - 1));
     } else if (e.key === 'Enter' && active >= 0) {
       e.preventDefault();
       const s = suggestions[active];
       onSelectSuggestion?.(s.id, s.type);
     }
   };
+
+  React.useEffect(() => {
+    if (!suggestions) return;
+    setActive((a) => Math.min(Math.max(a, -1), suggestions.length - 1));
+  }, [suggestions]);
 
   return (
     <header className={className} data-testid={dataTestId} role="search">
@@ -72,6 +77,7 @@ export const Header: React.FC<HeaderProps> = ({
             onSearch(val);
           }}
           onKeyDown={handleKeyDown}
+          aria-activedescendant={active >= 0 ? `suggestion-${active}` : undefined}
           className="flex-1 rounded border p-2"
           placeholder="Search"
         />
@@ -84,7 +90,9 @@ export const Header: React.FC<HeaderProps> = ({
           {suggestions.map((s, i) => (
             <li
               key={s.id}
+              id={`suggestion-${i}`}
               role="option"
+              aria-selected={active === i}
               className={`p-2 hover:bg-primary-300 cursor-pointer ${
                 active === i ? 'bg-primary-300' : ''
               }`}

--- a/test/headerAccessibility.test.tsx
+++ b/test/headerAccessibility.test.tsx
@@ -1,0 +1,27 @@
+import { TextEncoder, TextDecoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Header } from '../src/components/Header';
+
+expect.extend(toHaveNoViolations);
+
+test('Header suggestions list has no accessibility violations', async () => {
+  const { container } = render(
+    <BrowserRouter>
+      <Header
+        onSearch={() => {}}
+        suggestions={[
+          { id: '1', label: 'One', type: 'book' },
+          { id: '2', label: 'Two', type: 'book' },
+        ]}
+      />
+    </BrowserRouter>
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});


### PR DESCRIPTION
## Summary
- keep active suggestion index in range and expose stable IDs
- mark selected suggestion and wire up aria-activedescendant
- test Header component with jest-axe

## Testing
- `npm test --silent`
- `npm run test:axe --silent`


------
https://chatgpt.com/codex/tasks/task_e_688d2f687d688331b56580b873e33149