### PR TITLE
Add offline status banner

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { getOfflineEdits } from './nostr/offline';
+import { useToast } from './components/ToastProvider';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -7,6 +8,8 @@ interface AppShellProps {
 
 export const AppShell: React.FC<AppShellProps> = ({ children }) => {
   const [pending, setPending] = useState(0);
+  const [online, setOnline] = useState(navigator.onLine);
+  const toast = useToast();
 
   useEffect(() => {
     getOfflineEdits().then((edits) => setPending(edits.length));
@@ -21,8 +24,25 @@ export const AppShell: React.FC<AppShellProps> = ({ children }) => {
     return () => window.removeEventListener('offline-queue', handler);
   }, []);
 
+  useEffect(() => {
+    const updateStatus = () => {
+      const status = navigator.onLine;
+      setOnline(status);
+      if (!status) toast('You are offline', { type: 'error' });
+    };
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+    };
+  }, [toast]);
+
   return (
     <div className="min-h-screen bg-[color:var(--clr-surface)] text-[color:var(--clr-text)]">
+      {!online && (
+        <div className="bg-red-600 text-white text-center text-sm p-2">You are offline</div>
+      )}
       {pending > 0 && (
         <div className="bg-yellow-200 text-center text-sm p-2">
           {pending} action{pending !== 1 ? 's' : ''} pending sync


### PR DESCRIPTION
## Summary
- detect browser online/offline status in `AppShell`
- show offline banner and toast when disconnected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d30aee7348331ba029482e8074a99