### PR TITLE
Add relay list management in settings

### DIFF
--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -7,6 +7,7 @@ import { useNostr } from '../nostr';
 import { verifyNip05 } from '../nostr/events';
 import { getPrivKey } from '../nostr/auth';
 import { Button, Input } from '../components/ui';
+import { RelayListManager } from '../components/RelayListManager';
 import { isValidUrl, isValidNip05 } from '../validators';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
@@ -172,6 +173,7 @@ export const ProfileSettingsPage: React.FC = () => {
           </div>
         </div>
       </div>
+      <RelayListManager />
       <div className="flex gap-2">
         <Button
           onClick={handleSave}


### PR DESCRIPTION
## Summary
- let users configure Nostr relays on the profile settings page
- update ProfileSettings to render `RelayListManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d374234f883318b850fc89b8ff53e