### PR TITLE
Add search relay support

### DIFF
--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -57,6 +57,23 @@ export function setMaxEventSize(size: number) {
   }
 }
 
+export async function getSearchRelays(pubkey: string): Promise<string[]> {
+  const pool = new SimplePool();
+  const relays = DEFAULT_RELAYS ?? [];
+  try {
+    const events = (await pool.list(relays, [
+      { kinds: [10007], authors: [pubkey], limit: 1 },
+    ])) as NostrEvent[];
+    const evt = events[0];
+    if (!evt) return [];
+    return evt.tags.filter((t) => t[0] === 'r').map((t) => t[1]);
+  } catch {
+    return [];
+  } finally {
+    if (relays.length) pool.close(relays);
+  }
+}
+
 function checkDelegationConditions(
   cond: string,
   kind: number,


### PR DESCRIPTION
## Summary
- read search relay list from `kind:10007` events via new `getSearchRelays`
- query user search relays in `search.ts`
- combine API and relay suggestions without duplicates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d41050ce88331acb060c65203f29e