### PR TITLE
Add server route and config docs

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,3 +1,9 @@
+/**
+ * Configuration for the API server. Each relay entry defines where published
+ * events are forwarded and how much history is retained. Only relays that
+ * support NIP‑27 and whose `retentionDays` is at least `prunePolicy.minimumDays`
+ * will receive events.
+ */
 const relays = [
   { url: 'wss://relay.damus.io', supportsNip27: true, retentionDays: 365 },
   { url: 'wss://relay.primal.net', supportsNip27: true, retentionDays: 30 },

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,21 @@
+/**
+ * Node API server used in production.
+ *
+ * Routes:
+ *   POST `${API_BASE}/action`    – publish an action event to configured relays
+ *   POST `${API_BASE}/event`     – publish an arbitrary event to configured relays
+ *   POST `${API_BASE}/subscribe` – (placeholder) subscribe to updates
+ *   DELETE `${API_BASE}/subscribe` – (placeholder) cancel subscription
+ *
+ * Events are forwarded using `SimplePool` from `nostr-tools`. Targets are the
+ * relays listed in `server/config.js` whose retention meets `prunePolicy` and
+ * support NIP‑27. Non NIP‑27 relays receive versions suffixed with `-v<nr>`.
+ *
+ * Configuration options come from `server/config.js`:
+ *   - `relays`: array of relay definitions `{ url, supportsNip27, retentionDays }`
+ *   - `prunePolicy.minimumDays`: minimum retention required when forwarding
+ *                                 replaceable events
+ */
 const path = require('path');
 const express = require('express');
 const { SimplePool, verifyEvent } = require('nostr-tools');


### PR DESCRIPTION
## Summary
- document Express routes and publishing logic in `server/index.js`
- explain `relays` and `prunePolicy` options in `server/config.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d52998e148331a566a2582423b1c1