### PR TITLE
Add search relay docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For details on the HTML permitted in Markdown, see
 
 ## Nostr Features
 
-Read about managing relays, creating delegation tags and using the chat modals in
+Read about managing relays, creating delegation tags, configuring search relays and using the chat modals in
 [docs/nostr_features.md](docs/nostr_features.md).
 
 Bookstr looks for a user's published lists to discover more of their content:
@@ -69,6 +69,7 @@ Bookstr looks for a user's published lists to discover more of their content:
 - **kind `10002`** lists the relays a user writes to.
 - **kind `10003`** stores bookmarks.
 - **kind `30004`** captures their curation sets.
+- **kind `10007`** enumerates search relays. See the [Search Relays section](docs/nostr_features.md#search-relays).
 The app loads these when viewing a profile so your library includes books and
 relays the author recommends.
 

--- a/docs/nostr_features.md
+++ b/docs/nostr_features.md
@@ -11,6 +11,16 @@ The **RelayListManager** component in the profile settings screen allows you to 
 
 All changes are stored as kind `10002` events so the new relay list is shared across devices.
 
+## Search Relays
+
+Preferred search relays are stored in `kind:10007` events. When the SearchRelayManager UI is added to the profile settings you will be able to:
+
+1. Enter a `wss://` URL and press **Add** to include it.
+2. Click **Remove** beside an address to delete it.
+
+The updated list is saved as a `kind:10007` event so other clients can reuse your search preferences.
+
+
 ## Delegations
 
 Use **DelegationManager** from the profile settings to generate delegation tags for another pubkey:


### PR DESCRIPTION
## Summary
- explain how kind:10007 events store preferred search relays
- mention upcoming SearchRelayManager UI in docs
- link the new section from README and note kind 10007

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5969c96883318ae3c7aab75910a3