### PR TITLE
Add env example and README instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example environment configuration for Bookstr
+
+# Comma separated list of default Nostr relay URLs
+VITE_RELAY_URLS=
+
+# Base path for API requests
+VITE_API_BASE=/api
+
+# Push notification VAPID public key
+VITE_VAPID_PUBLIC_KEY=
+
+# Build metadata
+VITE_APP_VERSION=
+VITE_COMMIT_SHA=
+VITE_BUILD_DATE=
+
+# API server configuration
+API_BASE=/api
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ The frontend reads certain configuration from Vite environment variables:
 The API server also honours `API_BASE` to match the frontend and `PORT` for
 the listening port.
 
+Copy `.env.example` to `.env` and adjust the values to configure your
+environment.
+
 ### Event History Cache
 
 Bookstr keeps an IndexedDB pointer for each record it indexes. Before requesting


### PR DESCRIPTION
## Summary
- add an `.env.example` with all supported environment variables
- mention copying the example file in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6216f0508331a26dacf09589bb84