### PR TITLE
Add bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ the listening port.
 Copy `.env.example` to `.env` and adjust the values to configure your
 environment.
 
+If you want to run the full setup with one command, execute:
+
+```bash
+./scripts/bootstrap.sh
+```
+This installs dependencies with `npm ci`, creates the `.env` file if it does
+not exist, runs the tests and builds the production bundle.
+
 ### Event History Cache
 
 Bookstr keeps an IndexedDB pointer for each record it indexes. Before requesting

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# install exact dependencies
+npm ci
+
+# copy env file if missing
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# run unit tests
+npm test
+
+# build production bundle
+npm run build


### PR DESCRIPTION
## Summary
- provide `scripts/bootstrap.sh` to install deps, set up `.env`, run tests and build
- mention the new script in README for a quick bootstrap option

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d63675a988331b8881797d363ad2a