### PR TITLE
Update deploy script and document clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ All of the above steps are automated by the helper script:
 ./scripts/build_and_deploy.sh
 ```
 
+This script assumes `node_modules` is absent and installs dependencies with
+`npm ci`.
+
 ### API Server Configuration
 
 The Docker image includes a Node server that serves the static frontend and

--- a/scripts/build_and_deploy.sh
+++ b/scripts/build_and_deploy.sh
@@ -2,7 +2,7 @@
 set -e
 
 # install dependencies
-npm install
+npm ci
 
 # run tests
 npm test


### PR DESCRIPTION
## Summary
- use `npm ci` instead of `npm install` when building and deploying
- document that the build script requires a clean `node_modules` folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d652388e08331aa6bbf4184af7a65