### PR TITLE
Add docker-compose development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,21 @@ If you want to run the full setup with one command, execute:
 ```bash
 ./scripts/bootstrap.sh
 ```
+
 This installs dependencies with `npm ci`, creates the `.env` file if it does
 not exist, runs the tests and builds the production bundle.
+
+### Development with Docker Compose
+
+Launch the API server and Vite dev server together:
+
+```bash
+docker-compose up
+```
+
+The API server listens on <http://localhost:3000> while the frontend is served
+by Vite on <http://localhost:5173>. Source files are mounted so changes trigger
+live reload.
 
 ### Event History Cache
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  api:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: sh -c "npm ci && node server/index.js"
+    ports:
+      - '3000:3000'
+    env_file:
+      - .env
+  vite:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: sh -c "npm ci && npm run dev -- --host 0.0.0.0 --port 5173"
+    ports:
+      - '5173:5173'
+    env_file:
+      - .env
+    depends_on:
+      - api
+volumes:
+  node_modules:


### PR DESCRIPTION
## Summary
- define docker-compose services for API and Vite dev servers
- document compose workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d661b8b248331aaaa848a8bc1123c