### PR TITLE
feat: restructure chapter publishing and toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ specification but functionality is limited.
   support for `dark`, `earthy`, `vibrant` and `pastel` modes.
 - **Service worker** – `src/sw.ts` provides offline caching and background sync
   for a Progressive Web App.
+- **Book publishing** – the `BookPublishWizard` creates chapter events and a
+  table-of-contents so books can be read one chapter at a time.
 
 ## Settings
 

--- a/docs/first_publish.md
+++ b/docs/first_publish.md
@@ -17,13 +17,14 @@ Open the "Write" screen or choose **Publish Book** from the library. The wizard 
 
 On the final screen you can review the preview. Tick **Enable proof-of-work** if desired to add a small PoW to the event before clicking **Publish**. Successful publishing calls `reportBookPublished()` and unlocks the _First Book Published_ achievement.
 
-## 4. Locating the Event
+## 4. What Gets Published
 
 After publishing, the wizard returns to the first step. Two events are sent:
-the long-form `kind:30023` entry and a matching `kind:41` list event that
-references it. This list event ensures your book appears in the library and in
-`BookListScreen`. Most clients will show the events in your profile or search
-results a few seconds after publication.
+
+1. The first chapter as a `kind:30023` event with a `d` tag formatted as
+   `<bookId>:ch1` and a `part` tag of `1`.
+2. A `kind:41` table of contents that stores the book metadata and references
+   the chapter ID via `e` tags.
 
 ## 5. Large Chapters
 

--- a/src/components/ChapterEditorModal.tsx
+++ b/src/components/ChapterEditorModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNostr } from '../nostr';
-import { publishLongPost } from '../nostr/events';
+import { publishChapter, listChapters, publishToc } from '../nostr/events';
 import { queueOfflineEdit } from '../nostr/offline';
 import { useToast } from './ToastProvider';
 import { logError } from '../lib/logger';
@@ -28,7 +28,7 @@ export const ChapterEditorModal: React.FC<Props> = ({
   viaApi,
 }) => {
   const ctx = useNostr();
-  const { publish, subscribe, list, pubkey } = ctx;
+  const { subscribe, pubkey } = ctx;
   const toast = useToast();
   const [title, setTitle] = useState('');
   const [summary, setSummary] = useState('');
@@ -57,10 +57,6 @@ export const ChapterEditorModal: React.FC<Props> = ({
       toast('Action failed', { type: 'error' });
       return;
     }
-    const baseTags: string[][] = [
-      ['book', bookId],
-      ['chapter', String(chapterNumber)],
-    ];
     const tTags = tags
       .split(',')
       .map((t) => t.trim())
@@ -70,15 +66,12 @@ export const ChapterEditorModal: React.FC<Props> = ({
       summary: summary || undefined,
       content,
       cover: cover || undefined,
-      extraTags: baseTags,
       tags: tTags,
-      bookId,
-      chapterNumber,
     };
     let evt: any;
     try {
       if (!navigator.onLine) throw new Error('offline');
-      evt = await publishLongPost(ctx, data);
+      evt = await publishChapter(ctx, bookId, chapterNumber, data);
       if (viaApi) {
         await fetch(`${API_BASE}/event`, {
           method: 'POST',
@@ -91,46 +84,32 @@ export const ChapterEditorModal: React.FC<Props> = ({
       await queueOfflineEdit({
         id: Math.random().toString(36).slice(2),
         type: 'chapter',
-        data,
+        data: { ...data, bookId, chapterNumber },
       });
       toast('Saved offline, will sync later');
       onClose();
       return;
     }
 
-    let listEvt: any = null;
-    if (pubkey) {
-      await new Promise<void>((resolve) => {
-        const off = subscribe(
-          [{ kinds: [30001], authors: [authorPubkey], '#d': [bookId], limit: 1 }],
-          (e) => {
-            listEvt = e;
-            off();
-            resolve();
-          },
-        );
-        setTimeout(() => {
-          off();
-          resolve();
-        }, 2000);
-      });
-    }
-    const ids =
-      listEvt?.tags
-        .filter((t: string[]) => t[0] === 'e')
-        .map((t: string[]) => t[1]) || [];
+    const { toc } = await listChapters(ctx, bookId);
+    const ids = toc?.tags.filter((t) => t[0] === 'e').map((t) => t[1]) || [];
+    const meta = {
+      title: toc?.tags.find((t) => t[0] === 'title')?.[1],
+      summary: toc?.tags.find((t) => t[0] === 'summary')?.[1],
+      cover: toc?.tags.find((t) => t[0] === 'image')?.[1],
+      tags: toc?.tags.filter((t) => t[0] === 't').map((t) => t[1]),
+    };
     if (ids.length < chapterNumber) {
       ids.push(evt.id);
     } else {
       ids[chapterNumber - 1] = evt.id;
     }
-    const tagsOut = [['d', bookId], ...ids.map((i: string) => ['e', i])];
-    const listEvent = await publish({ kind: 30001, content: '', tags: tagsOut });
+    const tocEvt = await publishToc(ctx, bookId, ids, meta);
     if (viaApi) {
       await fetch(`${API_BASE}/event`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(listEvent),
+        body: JSON.stringify(tocEvt),
       });
     }
     onClose();

--- a/src/components/ReaderToolbar.tsx
+++ b/src/components/ReaderToolbar.tsx
@@ -8,6 +8,10 @@ export interface ReaderToolbarProps {
   onToggleTheme: () => void;
   onFontSize: (delta: 1 | -1) => void;
   onBookmark: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+  hasPrev?: boolean;
+  hasNext?: boolean;
   className?: string;
   'data-testid'?: string;
 }
@@ -22,6 +26,10 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
   onToggleTheme,
   onFontSize,
   onBookmark,
+  onPrev,
+  onNext,
+  hasPrev = false,
+  hasNext = false,
   className,
   'data-testid': dataTestId,
 }) => (
@@ -32,6 +40,26 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
     <button onClick={onBack} aria-label="Back" className="px-[var(--space-2)]">
       Back
     </button>
+    {onPrev && (
+      <button
+        onClick={onPrev}
+        aria-label="Previous chapter"
+        className="px-[var(--space-2)]"
+        disabled={!hasPrev}
+      >
+        Prev
+      </button>
+    )}
+    {onNext && (
+      <button
+        onClick={onNext}
+        aria-label="Next chapter"
+        className="px-[var(--space-2)]"
+        disabled={!hasNext}
+      >
+        Next
+      </button>
+    )}
     <div className="flex-1 text-center truncate">{title}</div>
     <button
       onClick={() => onFontSize(1)}

--- a/test/bookPublishMeta.test.js
+++ b/test/bookPublishMeta.test.js
@@ -24,8 +24,9 @@ const path = require('path');
   });
   const code = build.outputFiles[0].text;
   const module = { exports: {} };
-  let metaArgs;
+  let tocArgs;
   let onPublishId;
+  let chapterBookId;
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
@@ -33,8 +34,13 @@ const path = require('path');
       }
       if (p === './src/nostr/events.ts') {
         return {
-          publishLongPost: async () => ({ id: 'abc123' }),
-          publishBookMeta: async (...args) => { metaArgs = args; },
+          publishChapter: async (_ctx, id, num, data) => {
+            chapterBookId = id;
+            return { id: 'chap1' };
+          },
+          publishToc: async (...args) => {
+            tocArgs = args;
+          },
         };
       }
       if (p === './src/achievements.ts') {
@@ -85,7 +91,8 @@ const path = require('path');
     await Promise.resolve();
   });
 
-  assert.strictEqual(onPublishId, 'abc123');
-  assert.strictEqual(metaArgs[1], 'abc123');
+  assert.strictEqual(onPublishId, chapterBookId);
+  assert.strictEqual(tocArgs[1], chapterBookId);
+  assert.strictEqual(tocArgs[2][0], 'chap1');
   console.log('All tests passed.');
 })();

--- a/test/bookPublishToast.test.js
+++ b/test/bookPublishToast.test.js
@@ -31,7 +31,7 @@ const path = require('path');
         return { useNostr: () => ({}) };
       }
       if (p === './src/nostr/events.ts') {
-        return { publishLongPost: async () => { throw new Error('fail'); } };
+        return { publishChapter: async () => { throw new Error('fail'); } };
       }
       if (p === './src/achievements.ts') {
         return { reportBookPublished: () => {} };


### PR DESCRIPTION
## Summary
- add Nostr helpers to publish chapters, list them and manage table of contents
- create first chapter and table of contents from `BookPublishWizard`
- load chapters for reading with next/previous navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d68231b048331a05e02c2546eb7bf