### PR TITLE
feat: add list creation page and profile integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ specification but functionality is limited.
   for a Progressive Web App.
 - **Book publishing** – the `BookPublishWizard` creates chapter events and a
   table-of-contents so books can be read one chapter at a time.
+- **List publishing** – create private (`kind 10003`) or public (`kind 30004`)
+  book collections from `/lists/new`. Lists you own appear on your profile with
+  quick links to edit them.
 
 ## Settings
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ import { Discover } from './components/Discover';
 import LibraryPage from './pages/Library';
 import ManageChaptersPage from './pages/ManageChapters';
 import { BookPublishWizard } from './components/BookPublishWizard';
-import { ListPublishWizard } from './components/ListPublishWizard';
+import ListCreatePage from './pages/ListCreate';
 import { NotificationFeed } from './components/NotificationFeed';
 import ProfileSettingsPage from './pages/ProfileSettings';
 import UISettingsPage from './pages/UISettings';
@@ -113,7 +113,7 @@ const AppRoutes: React.FC = () => (
       <Route path="discover" element={<Discover />} />
       <Route path="library" element={<LibraryPage />} />
       <Route path="write" element={<BookPublishWizard />} />
-      <Route path="lists/new" element={<ListPublishWizard />} />
+      <Route path="lists/new" element={<ListCreatePage />} />
       <Route path="activity" element={<NotificationFeed />} />
       <Route path="profile" element={<ProfileScreen />} />
       <Route path="settings" element={<SettingsHome />} />

--- a/src/pages/ListCreate.tsx
+++ b/src/pages/ListCreate.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ListPublishWizard } from '../components/ListPublishWizard';
+
+/**
+ * Page that wraps the list publishing wizard.
+ */
+const ListCreatePage: React.FC = () => {
+  return <ListPublishWizard />;
+};
+
+export default ListCreatePage;

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -134,13 +134,14 @@ export const ProfileScreen: React.FC = () => {
   useEffect(() => {
     if (!pubkey) return;
     (async () => {
+      const kinds = pubkey === loggedPubkey ? [10003, 30004] : [30004];
       const evts = (await listWithExtras([
-        { kinds: [10003, 30004], authors: [pubkey] },
+        { kinds, authors: [pubkey] },
       ])) as NostrEvent[];
       evts.forEach(addEvent);
       setBookLists(evts);
     })();
-  }, [pubkey, addEvent, ctxRelays, extraRelays]);
+  }, [pubkey, loggedPubkey, addEvent, ctxRelays, extraRelays]);
 
   if (!pubkey) return null;
 
@@ -212,7 +213,10 @@ export const ProfileScreen: React.FC = () => {
                     <ListFollowButton author={evt.pubkey} d={d} />
                   )}
                   {d && pubkey === loggedPubkey && (
-                    <Link to="/lists/new" className="rounded border px-2 py-1">
+                    <Link
+                      to={`/lists/new?d=${encodeURIComponent(d)}`}
+                      className="rounded border px-2 py-1"
+                    >
                       Edit list
                     </Link>
                   )}

--- a/test/jest/LoginModal.test.tsx
+++ b/test/jest/LoginModal.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { LoginModal } from '../../src/components/LoginModal';
 
+jest.mock('../../src/components/ToastProvider', () => ({
+  useToast: () => jest.fn(),
+}));
+
 jest.mock('../../src/nostr', () => ({
   useNostr: () => ({
     login: jest.fn(),

--- a/test/jest/listCreationProfile.test.tsx
+++ b/test/jest/listCreationProfile.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ListPublishWizard } from '../../src/components/ListPublishWizard';
+import { ProfileScreen } from '../../src/screens/ProfileScreen';
+
+jest.mock('../../src/components/ToastProvider', () => ({
+  useToast: () => jest.fn(),
+}));
+
+let nostrMocks: any = {};
+
+jest.mock('../../src/nostr', () => ({
+  useNostr: () => nostrMocks,
+}));
+
+jest.mock('../../src/components/BookCard', () => ({
+  BookCard: () => <div data-testid="book-card" />,
+}));
+
+jest.mock('../../src/components/ListFollowButton', () => ({
+  ListFollowButton: () => <div />,
+}));
+
+jest.mock('../../src/store/events', () => ({
+  useEventStore: (sel: any) => sel({ addEvent: jest.fn() }),
+}));
+
+jest.mock('../../src/nostr/relays', () => ({
+  fetchUserRelays: jest.fn(async () => []),
+}));
+
+describe('List creation and profile display', () => {
+  beforeEach(() => {
+    const publishMock = jest.fn(async () => ({ id: 'evt1' }));
+    const listMock = jest.fn(async (filters: any[]) => {
+      const kinds = filters[0].kinds || [];
+      if (kinds.includes(30001)) {
+        return [
+          { tags: [['e', 'b1']] },
+        ];
+      }
+      if (kinds.includes(41)) {
+        return [
+          { tags: [['d', 'b1'], ['title', 'Book 1']] },
+        ];
+      }
+      if (kinds.includes(10003) || kinds.includes(30004)) {
+        return [
+          {
+            id: 'l1',
+            kind: 30004,
+            pubkey: 'pk1',
+            created_at: 0,
+            content: '',
+            tags: [['d', 'list1'], ['name', 'List One'], ['a', '41:pk1:b1']],
+          },
+          {
+            id: 'l2',
+            kind: 10003,
+            pubkey: 'pk1',
+            created_at: 0,
+            content: '',
+            tags: [['d', 'list2'], ['name', 'List Two'], ['a', '41:pk1:b2']],
+          },
+        ];
+      }
+      return [];
+    });
+    const subscribeMock = jest.fn(() => () => {});
+    nostrMocks = {
+      pubkey: 'pk1',
+      list: listMock,
+      publish: publishMock,
+      subscribe: subscribeMock,
+    };
+  });
+
+  test('publishes private and public lists with correct kind', async () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ListPublishWizard />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('List name'), {
+      target: { value: 'My List' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Description'), {
+      target: { value: 'Desc' },
+    });
+    fireEvent.click(screen.getByLabelText('Private list'));
+    fireEvent.click(screen.getByText('Next'));
+    await screen.findByText('Book 1');
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByText('Next'));
+    fireEvent.click(screen.getByText('Publish'));
+    await waitFor(() => expect(nostrMocks.publish).toHaveBeenCalled());
+    expect(nostrMocks.publish.mock.calls[0][0].kind).toBe(10003);
+
+    // rerender for public list
+    nostrMocks.publish.mockClear();
+    rerender(
+      <MemoryRouter>
+        <ListPublishWizard />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByPlaceholderText('List name'), {
+      target: { value: 'My Public List' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Description'), {
+      target: { value: 'Desc' },
+    });
+    fireEvent.click(screen.getByText('Next'));
+    await screen.findByText('Book 1');
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByText('Next'));
+    fireEvent.click(screen.getByText('Publish'));
+    await waitFor(() => expect(nostrMocks.publish).toHaveBeenCalled());
+    expect(nostrMocks.publish.mock.calls[0][0].kind).toBe(30004);
+  });
+
+  test('shows owned lists on profile with edit options', async () => {
+    render(
+      <MemoryRouter initialEntries={['/profile']}>
+        <Routes>
+          <Route path="/profile" element={<ProfileScreen />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText('list1')).toBeInTheDocument());
+    expect(screen.getByText('list2')).toBeInTheDocument();
+    expect(screen.getByText('Create List')).toBeInTheDocument();
+    expect(screen.getAllByText('Edit list').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated ListCreate page wrapping ListPublishWizard
- show owned lists on profile with create and edit links
- document list publishing and add tests for publishing and profile display

## Testing
- `npm test`
- `npm run test:rtl`


------
https://chatgpt.com/codex/tasks/task_e_688d6fcfe5c883318f5de743ea037e32