### PR TITLE
feat: show reading progress and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ specification but functionality is limited.
   for a Progressive Web App.
 - **Book publishing** – the `BookPublishWizard` creates chapter events and a
   table-of-contents so books can be read one chapter at a time.
+- **Reading progress indicators** – the reader toolbar displays your current
+  percentage with **Previous chapter** and **Next chapter** controls, and book
+  cards show a small progress bar.
 - **List publishing** – create private (`kind 10003`) or public (`kind 30004`)
   book collections from `/lists/new`. Lists you own appear on your profile with
   quick links to edit them.

--- a/docs/first_publish.md
+++ b/docs/first_publish.md
@@ -33,3 +33,10 @@ default). When a chapter is longer, `publishLongPost` slices the text into
 numbered parts. Each part shares a unique `d` tag and stores its position with a
 `part` index. The reader collects all events with the same `d` value and
 concatenates them before rendering so the full chapter is shown to the user.
+
+## Reading Progress
+
+When you open your published book in the reader, the toolbar now shows your
+current percentage and provides **Previous chapter** and **Next chapter**
+buttons. Book cards in the library also display a small progress indicator so
+you can track your reading at a glance.

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -5,10 +5,12 @@ import { ReactionButton } from './ReactionButton';
 import { RepostButton } from './RepostButton';
 import { DeleteButton } from './DeleteButton';
 import { ReportButton } from './ReportButton';
+import { ProgressBar } from './ProgressBar';
 import { FaHeart } from 'react-icons/fa';
 import type { Event as NostrEvent } from 'nostr-tools';
 import { logEvent } from '../analytics';
 import { OnboardingTooltip } from './OnboardingTooltip';
+import { useReadingStore } from '../store';
 
 interface BookCardProps {
   event: NostrEvent & { repostedBy?: string };
@@ -25,6 +27,9 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
   const ctx = useNostr();
   const [status, setStatus] = useState<'idle' | 'zapping' | 'done'>('idle');
   const { toggleBookmark, bookmarks, pubkey, subscribe } = ctx;
+  const percent = useReadingStore(
+    (s) => s.books.find((b) => b.id === event.id)?.percent ?? 0,
+  );
   const [attachments, setAttachments] = useState<
     { id: string; mime: string; url: string }[]
   >([]);
@@ -77,6 +82,9 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
       )}
       <h3 className="font-semibold">{title}</h3>
       {summary && <p className="text-sm text-text-muted">{summary}</p>}
+      <div className="mt-2">
+        <ProgressBar value={percent} data-testid="book-progress" />
+      </div>
       {attachments.map((a) => (
         <a
           key={a.id}

--- a/src/components/ReaderToolbar.tsx
+++ b/src/components/ReaderToolbar.tsx
@@ -47,7 +47,7 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
         className="px-[var(--space-2)]"
         disabled={!hasPrev}
       >
-        Prev
+        Previous chapter
       </button>
     )}
     {onNext && (
@@ -57,7 +57,7 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
         className="px-[var(--space-2)]"
         disabled={!hasNext}
       >
-        Next
+        Next chapter
       </button>
     )}
     <div className="flex-1 text-center truncate">{title}</div>
@@ -88,6 +88,6 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
     >
       ★
     </button>
-    <span className="ml-2 text-sm text-text-muted">{percent}%</span>
+    <span className="ml-2 text-sm text-text-muted">{Math.round(percent)}%</span>
   </div>
 );

--- a/test/readerProgressNavigation.test.js
+++ b/test/readerProgressNavigation.test.js
@@ -1,0 +1,161 @@
+require('ts-node/register');
+const assert = require('assert');
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const esbuild = require('esbuild');
+const vm = require('vm');
+const path = require('path');
+
+(async () => {
+  const build = await esbuild.build({
+    entryPoints: [path.join(__dirname, '../src/screens/ReaderScreen.tsx')],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    write: false,
+    external: [
+      'react',
+      'react-router-dom',
+      './src/nostr.tsx',
+      './src/nostr/events.ts',
+      './src/components/ReaderToolbar.tsx',
+      './src/components/ProgressBar.tsx',
+      './src/components/ReaderView.tsx',
+      './src/components/ui/index.ts',
+      './src/ThemeProvider.tsx',
+      './src/store.ts',
+    ],
+  });
+  const code = build.outputFiles[0].text;
+  const module = { exports: {} };
+  const progressCalls = [];
+  const navigateCalls = [];
+  let triggerPercent;
+  const sandbox = {
+    require: (p) => {
+      if (p === 'react-router-dom') {
+        return {
+          useParams: () => ({ bookId: '1' }),
+          useNavigate: () => (arg) => navigateCalls.push(arg),
+        };
+      }
+      if (p === './src/nostr.tsx') {
+        return { useNostr: () => ({}) };
+      }
+      if (p === './src/nostr/events.ts') {
+        return {
+          listChapters: async () => ({
+            chapters: [
+              { tags: [['title', 'First']] },
+              { tags: [['title', 'Second']] },
+            ],
+          }),
+          fetchLongPostParts: async () => '<p>content</p>',
+        };
+      }
+      if (p === './src/components/ReaderToolbar.tsx') {
+        return {
+          ReaderToolbar: ({ title, onPrev, onNext, hasPrev, hasNext }) =>
+            React.createElement(
+              'div',
+              {},
+              React.createElement(
+                'button',
+                { onClick: onPrev, disabled: !hasPrev },
+                'Prev',
+              ),
+              React.createElement('span', { 'data-testid': 'title' }, title),
+              React.createElement(
+                'button',
+                { onClick: onNext, disabled: !hasNext },
+                'Next',
+              ),
+            ),
+        };
+      }
+      if (p === './src/components/ProgressBar.tsx') {
+        return { ProgressBar: () => React.createElement('div') };
+      }
+      if (p === './src/components/ReaderView.tsx') {
+        return {
+          ReaderView: (props) => {
+            triggerPercent = props.onPercentChange;
+            return React.createElement('div');
+          },
+        };
+      }
+      if (p === './src/components/ui/index.ts') {
+        return {
+          Button: ({ onClick, children }) =>
+            React.createElement('button', { onClick }, children),
+        };
+      }
+      if (p === './src/ThemeProvider.tsx') {
+        return { useTheme: () => ({ theme: 'default', setTheme: () => {} }) };
+      }
+      if (p === './src/store.ts') {
+        return {
+          useReadingStore: (sel) =>
+            sel({
+              updateProgress: (id, pct) => progressCalls.push([id, pct]),
+              finishBook: () => {},
+            }),
+        };
+      }
+      if (p === 'react') {
+        return React;
+      }
+      return require(p);
+    },
+    module,
+    exports: module.exports,
+    TextEncoder,
+    TextDecoder,
+    React,
+  };
+  vm.runInNewContext(code, sandbox, { filename: 'ReaderScreen.js' });
+  const { ReaderScreen } = module.exports;
+
+  let renderer;
+  await TestRenderer.act(async () => {
+    renderer = TestRenderer.create(React.createElement(ReaderScreen));
+    await Promise.resolve();
+  });
+  await TestRenderer.act(async () => {
+    await Promise.resolve();
+  });
+
+  await TestRenderer.act(async () => {
+    triggerPercent(42);
+    await Promise.resolve();
+  });
+
+  assert.deepStrictEqual(progressCalls, [['1', 42]], 'progress should update');
+
+  await TestRenderer.act(async () => {
+    const nextBtn = renderer.root
+      .findAllByType('button')
+      .find((b) => b.children.includes('Next'));
+    nextBtn.props.onClick();
+    await Promise.resolve();
+  });
+  await TestRenderer.act(async () => {
+    await Promise.resolve();
+  });
+  const titleEl = renderer.root.findByProps({ 'data-testid': 'title' });
+  assert.strictEqual(titleEl.children[0], 'Second', 'should show second chapter');
+
+  await TestRenderer.act(async () => {
+    const prevBtn = renderer.root
+      .findAllByType('button')
+      .find((b) => b.children.includes('Prev'));
+    prevBtn.props.onClick();
+    await Promise.resolve();
+  });
+  await TestRenderer.act(async () => {
+    await Promise.resolve();
+  });
+  assert.strictEqual(titleEl.children[0], 'First', 'should show first chapter');
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- show explicit "Previous chapter" / "Next chapter" buttons in reader toolbar and display rounded percent complete
- display reading progress bar on each BookCard using data from the reading store
- document reading progress indicators in README and first publish guide
- add tests for reader progress updates and chapter navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d7276ec388331a820d0c58ce087fa