### PR TITLE
feat: add home feed

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { FaCompass, FaBookOpen, FaPen, FaBell, FaUser } from 'react-icons/fa';
+import { FaCompass, FaBookOpen, FaPen, FaBell, FaUser, FaHome } from 'react-icons/fa';
 import type { IconType } from 'react-icons';
 
-type NavKey = 'discover' | 'library' | 'write' | 'activity' | 'profile';
+type NavKey = 'home' | 'discover' | 'library' | 'write' | 'activity' | 'profile';
 
 export interface BottomNavProps {
   active: NavKey;
@@ -12,6 +12,7 @@ export interface BottomNavProps {
 }
 
 const items: Array<{ key: NavKey; label: string; Icon: IconType }> = [
+  { key: 'home', label: 'Home', Icon: FaHome },
   { key: 'discover', label: 'Discover', Icon: FaCompass },
   { key: 'library', label: 'Library', Icon: FaBookOpen },
   { key: 'write', label: 'Write', Icon: FaPen },

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useNostr } from '../nostr';
+import { ReactionButton } from './ReactionButton';
+import { RepostButton } from './RepostButton';
+import { DeleteButton } from './DeleteButton';
+import { ReportButton } from './ReportButton';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+interface NoteCardProps {
+  event: NostrEvent & { repostedBy?: string };
+  onDelete?: (id: string) => void;
+}
+
+/**
+ * Display a note event with basic interactions.
+ */
+export const NoteCard: React.FC<NoteCardProps> = ({ event, onDelete }) => {
+  const { pubkey } = useNostr();
+  return (
+    <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
+      {event.repostedBy && (
+        <p className="mb-[var(--space-1)] text-xs text-text-muted">
+          Reposted by {event.repostedBy}
+        </p>
+      )}
+      <p className="whitespace-pre-wrap">{event.content}</p>
+      <div className="pt-2 flex gap-2">
+        <ReactionButton target={event.id} type="vote" />
+        <RepostButton target={event.id} />
+        <ReportButton target={event.id} />
+        {pubkey === event.pubkey && (
+          <DeleteButton
+            target={event.id}
+            onDelete={() => onDelete?.(event.id)}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import { BookListScreen } from './screens/BookListScreen';
 import { BookDetailScreen } from './screens/BookDetailScreen';
 import { ReaderScreen } from './screens/ReaderScreen';
 import { Discover } from './components/Discover';
+import { HomeFeed } from './screens/HomeFeed';
 import LibraryPage from './pages/Library';
 import ManageChaptersPage from './pages/ManageChapters';
 import { BookPublishWizard } from './components/BookPublishWizard';
@@ -40,10 +41,11 @@ const Layout: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const active = React.useMemo<
-    'discover' | 'library' | 'write' | 'activity' | 'profile'
+    'home' | 'discover' | 'library' | 'write' | 'activity' | 'profile'
   >(() => {
     const key = location.pathname.split('/')[1];
     if (
+      key === 'home' ||
       key === 'discover' ||
       key === 'library' ||
       key === 'write' ||
@@ -110,7 +112,8 @@ const Layout: React.FC = () => {
 const AppRoutes: React.FC = () => (
   <Routes>
     <Route path="/" element={<Layout />}>
-      <Route index element={<Navigate to="discover" />} />
+      <Route index element={<Navigate to="home" />} />
+      <Route path="home" element={<HomeFeed />} />
       <Route path="discover" element={<Discover />} />
       <Route path="library" element={<LibraryPage />} />
       <Route path="write" element={<BookPublishWizard />} />

--- a/src/screens/HomeFeed.tsx
+++ b/src/screens/HomeFeed.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useNostr } from '../nostr';
+import { BookCard } from '../components/BookCard';
+import { NoteCard } from '../components/NoteCard';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+/**
+ * Home feed displaying events from followed users.
+ */
+export const HomeFeed: React.FC = () => {
+  const { contacts, subscribe } = useNostr();
+  const [events, setEvents] = useState<
+    (NostrEvent & { repostedBy?: string })[]
+  >([]);
+
+  useEffect(() => {
+    if (contacts.length === 0) return;
+    const off = subscribe(
+      [{ kinds: [1, 6, 30023, 41], authors: contacts, limit: 100 }],
+      (evt) => {
+        if (evt.kind === 6) {
+          const target = evt.tags.find((t) => t[0] === 'e')?.[1];
+          if (!target) return;
+          const offTarget = subscribe([{ ids: [target] }], (orig) => {
+            setEvents((e) => {
+              const idx = e.findIndex((x) => x.id === orig.id);
+              if (idx !== -1) {
+                const copy = [...e];
+                copy[idx] = { ...copy[idx], repostedBy: evt.pubkey };
+                return copy;
+              }
+              return [...e, { ...orig, repostedBy: evt.pubkey }];
+            });
+            offTarget();
+          });
+        } else {
+          setEvents((e) =>
+            e.find((x) => x.id === evt.id) ? e : [...e, evt],
+          );
+        }
+      },
+    );
+    return off;
+  }, [subscribe, contacts]);
+
+  const handleDelete = (id: string) =>
+    setEvents((evts) => evts.filter((x) => x.id !== id));
+
+  return (
+    <ul role="list" className="space-y-4">
+      {events.map((e) => (
+        <li key={e.id} role="listitem">
+          {e.kind === 30023 ? (
+            <BookCard event={e} onDelete={handleDelete} />
+          ) : (
+            <NoteCard event={e} onDelete={handleDelete} />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};


### PR DESCRIPTION
## Summary
- implement HomeFeed screen subscribing to followed authors
- add NoteCard component for note events
- wire new Home route and navigation entry

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d7bfd2108833191fc9aca0351c6dd