### PR TITLE
feat: announce publications

### DIFF
--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { marked } from 'marked';
-import { useNostr } from '../nostr';
+import { useNostr, publishAnnouncement } from '../nostr';
 import { useToast } from './ToastProvider';
 import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';
@@ -24,6 +24,7 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
   const [tags, setTags] = useState('');
   const [content, setContent] = useState('');
   const [pow, setPow] = useState(false);
+  const [announce, setAnnounce] = useState(true);
   const [publishing, setPublishing] = useState(false);
   const previewHtml = useMemo(
     () => sanitizeHtml(marked.parse(content)),
@@ -74,11 +75,16 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
       setTags('');
       setContent('');
       setPow(false);
+      setAnnounce(true);
+      if (announce) {
+        await publishAnnouncement(
+          ctx,
+          `📚 ${title} is live! nostr:naddr/${bookId}`,
+        );
+      }
       reportBookPublished();
       if (onPublish) onPublish(bookId);
-      toast(
-        `Book published! <a href="/book/${bookId}">View book</a>`,
-      );
+      toast(`Book published! <a href="/book/${bookId}">View book</a>`);
     } catch (err) {
       logError(err);
       toast('Failed to publish book.');
@@ -203,6 +209,14 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
               className="prose max-w-none"
             dangerouslySetInnerHTML={{ __html: previewHtml }}
           />
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={announce}
+              onChange={(e) => setAnnounce(e.target.checked)}
+            />
+            Post announcement
+          </label>
           <label className="flex items-center gap-2">
             <input
               type="checkbox"

--- a/src/nostr.tsx
+++ b/src/nostr.tsx
@@ -133,6 +133,14 @@ export interface NostrContextValue {
 
 const NostrContext = createContext<NostrContextValue | undefined>(undefined);
 
+export function publishAnnouncement(
+  ctx: NostrContextValue,
+  content: string,
+  tags: string[][] = [],
+): Promise<NostrEvent> {
+  return ctx.publish({ kind: 1, content, tags });
+}
+
 export const NostrProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {

--- a/src/pages/ManageChapters.tsx
+++ b/src/pages/ManageChapters.tsx
@@ -187,6 +187,7 @@ const ManageChaptersPage: React.FC = () => {
             load();
           }}
           viaApi
+          allowAnnouncement={!modal.id}
         />
       )}
     </div>

--- a/test/bookPublishMeta.test.js
+++ b/test/bookPublishMeta.test.js
@@ -30,7 +30,7 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
-        return { useNostr: () => ({}) };
+        return { useNostr: () => ({}), publishAnnouncement: async () => {} };
       }
       if (p === './src/nostr/events.ts') {
         return {

--- a/test/bookPublishToast.test.js
+++ b/test/bookPublishToast.test.js
@@ -28,7 +28,7 @@ const path = require('path');
   const sandbox = {
     require: (p) => {
       if (p === './src/nostr.tsx') {
-        return { useNostr: () => ({}) };
+        return { useNostr: () => ({}), publishAnnouncement: async () => {} };
       }
       if (p === './src/nostr/events.ts') {
         return { publishChapter: async () => { throw new Error('fail'); } };

--- a/test/chapterEditorModalAuth.test.js
+++ b/test/chapterEditorModalAuth.test.js
@@ -28,6 +28,7 @@ const path = require('path');
             subscribe: () => () => {},
             pubkey: 'user',
           }),
+          publishAnnouncement: async () => {},
         };
       }
       if (p === './src/components/ToastProvider.tsx') {

--- a/test/jest/BookPublishWizard.test.tsx
+++ b/test/jest/BookPublishWizard.test.tsx
@@ -4,6 +4,7 @@ import { BookPublishWizard } from '../../src/components/BookPublishWizard';
 
 jest.mock('../../src/nostr', () => ({
   useNostr: () => ({ publish: jest.fn() }),
+  publishAnnouncement: jest.fn(),
 }));
 
 jest.mock('../../src/components/ToastProvider', () => ({


### PR DESCRIPTION
## Summary
- add `publishAnnouncement` utility to wrap Nostr kind 1 events
- announce new books and chapters via optional checkbox in publish flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7f619ea48331988b579588233f78