### PR TITLE
feat: embed nostr references in notes

### DIFF
--- a/src/components/CommunityFeed.tsx
+++ b/src/components/CommunityFeed.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNostr } from '../nostr';
 import type { Event as NostrEvent } from 'nostr-tools';
+import { NoteCard } from './NoteCard';
 
 /**
  * Feed listing community posts from kind 172 events.
@@ -21,15 +22,11 @@ export const CommunityFeed: React.FC = () => {
 
   return (
     <ul role="list" className="space-y-4">
-      {events.map((evt) => {
-        const name = evt.tags.find((t) => t[0] === 'name')?.[1] || 'Unnamed';
-        return (
-          <li key={evt.id} role="listitem" className="rounded border p-2">
-            <h3 className="font-semibold">{name}</h3>
-            <p className="text-sm whitespace-pre-wrap">{evt.content}</p>
-          </li>
-        );
-      })}
+      {events.map((evt) => (
+        <li key={evt.id} role="listitem">
+          <NoteCard event={evt} />
+        </li>
+      ))}
     </ul>
   );
 };

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,21 +1,102 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { marked } from 'marked';
+import { nip19, type Event as NostrEvent, type Filter } from 'nostr-tools';
 import { useNostr } from '../nostr';
+import { sanitizeHtml } from '../sanitizeHtml';
 import { ReactionButton } from './ReactionButton';
 import { RepostButton } from './RepostButton';
 import { DeleteButton } from './DeleteButton';
 import { ReportButton } from './ReportButton';
-import type { Event as NostrEvent } from 'nostr-tools';
+import { BookCard } from './BookCard';
 
 interface NoteCardProps {
   event: NostrEvent & { repostedBy?: string };
   onDelete?: (id: string) => void;
 }
 
+// simple cache for fetched events
+const eventCache = new Map<string, NostrEvent>();
+
+const ChapterSnippet: React.FC<{ event: NostrEvent }> = ({ event }) => {
+  const title = event.tags.find((t) => t[0] === 'title')?.[1] ?? 'Untitled';
+  const summary = event.tags.find((t) => t[0] === 'summary')?.[1] ?? '';
+  return (
+    <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
+      <h4 className="font-semibold text-sm">{title}</h4>
+      {summary && (
+        <p className="text-sm text-text-muted">{summary}</p>
+      )}
+    </div>
+  );
+};
+
 /**
- * Display a note event with basic interactions.
+ * Display a note event with basic interactions and embedded nostr links.
  */
 export const NoteCard: React.FC<NoteCardProps> = ({ event, onDelete }) => {
-  const { pubkey } = useNostr();
+  const { list, pubkey } = useNostr();
+
+  if (event.kind === 30023) {
+    return <BookCard event={event} onDelete={onDelete} />;
+  }
+
+  const html = useMemo(
+    () => sanitizeHtml(marked.parse(event.content)),
+    [event.content],
+  );
+
+  const refs = useMemo(() => {
+    const matches = Array.from(
+      event.content.matchAll(/nostr:([a-z0-9]+)/gi),
+    );
+    const unique = new Set(matches.map((m) => m[1]));
+    return Array.from(unique);
+  }, [event.content]);
+
+  const [embedded, setEmbedded] = useState<NostrEvent[]>([]);
+
+  useEffect(() => {
+    refs.forEach((ref) => {
+      const cached = eventCache.get(ref);
+      if (cached) {
+        setEmbedded((prev) =>
+          prev.find((e) => e.id === cached.id) ? prev : [...prev, cached],
+        );
+        return;
+      }
+      (async () => {
+        try {
+          const decoded = nip19.decode(ref);
+          let filter: Filter | undefined;
+          if (decoded.type === 'nevent' || decoded.type === 'note') {
+            const id =
+              typeof decoded.data === 'string'
+                ? decoded.data
+                : decoded.data.id;
+            filter = { ids: [id] };
+          } else if (decoded.type === 'naddr') {
+            const data: any = decoded.data;
+            filter = {
+              kinds: [data.kind],
+              '#d': [data.identifier],
+              authors: [data.pubkey],
+            };
+          }
+          if (!filter) return;
+          const [evt] = await list([filter]);
+          if (evt) {
+            eventCache.set(ref, evt);
+            setEmbedded((prev) =>
+              prev.find((e) => e.id === evt.id) ? prev : [...prev, evt],
+            );
+          }
+        } catch {
+          // ignore invalid references
+        }
+      })();
+    });
+  }, [refs, list]);
+
   return (
     <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
       {event.repostedBy && (
@@ -23,7 +104,19 @@ export const NoteCard: React.FC<NoteCardProps> = ({ event, onDelete }) => {
           Reposted by {event.repostedBy}
         </p>
       )}
-      <p className="whitespace-pre-wrap">{event.content}</p>
+      <div
+        className="prose max-w-none whitespace-pre-wrap"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      {embedded.map((ev) => (
+        <div key={ev.id} className="mt-[var(--space-2)]">
+          {ev.kind === 30023 ? (
+            <BookCard event={ev} />
+          ) : (
+            <ChapterSnippet event={ev} />
+          )}
+        </div>
+      ))}
       <div className="pt-2 flex gap-2">
         <ReactionButton target={event.id} type="vote" />
         <RepostButton target={event.id} />

--- a/src/screens/HomeFeed.tsx
+++ b/src/screens/HomeFeed.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useNostr } from '../nostr';
-import { BookCard } from '../components/BookCard';
 import { NoteCard } from '../components/NoteCard';
 import type { Event as NostrEvent } from 'nostr-tools';
 
@@ -50,11 +49,7 @@ export const HomeFeed: React.FC = () => {
     <ul role="list" className="space-y-4">
       {events.map((e) => (
         <li key={e.id} role="listitem">
-          {e.kind === 30023 ? (
-            <BookCard event={e} onDelete={handleDelete} />
-          ) : (
-            <NoteCard event={e} onDelete={handleDelete} />
-          )}
+          <NoteCard event={e} onDelete={handleDelete} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- render notes with markdown and embedded `nostr:` links
- show note cards in CommunityFeed and HomeFeed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8111883883319734b67c16dd6d86