### PR TITLE
feat: show reading progress and chapter navigation

### DIFF
--- a/src/components/ReaderToolbar.tsx
+++ b/src/components/ReaderToolbar.tsx
@@ -34,60 +34,64 @@ export const ReaderToolbar: React.FC<ReaderToolbarProps> = ({
   'data-testid': dataTestId,
 }) => (
   <div
-    className={`flex items-center justify-between gap-2 p-[var(--space-2)] ${className ?? ''}`}
+    className={`flex items-center gap-2 p-[var(--space-2)] ${className ?? ''}`}
     data-testid={dataTestId}
   >
-    <button onClick={onBack} aria-label="Back" className="px-[var(--space-2)]">
-      Back
-    </button>
-    {onPrev && (
-      <button
-        onClick={onPrev}
-        aria-label="Previous chapter"
-        className="px-[var(--space-2)]"
-        disabled={!hasPrev}
-      >
-        Previous chapter
+    <div className="flex items-center gap-2">
+      <button onClick={onBack} aria-label="Back" className="px-[var(--space-2)]">
+        Back
       </button>
-    )}
-    {onNext && (
-      <button
-        onClick={onNext}
-        aria-label="Next chapter"
-        className="px-[var(--space-2)]"
-        disabled={!hasNext}
-      >
-        Next chapter
-      </button>
-    )}
+      {onPrev && (
+        <button
+          onClick={onPrev}
+          aria-label="Previous chapter"
+          className="px-[var(--space-2)]"
+          disabled={!hasPrev}
+        >
+          Previous chapter
+        </button>
+      )}
+      {onNext && (
+        <button
+          onClick={onNext}
+          aria-label="Next chapter"
+          className="px-[var(--space-2)]"
+          disabled={!hasNext}
+        >
+          Next chapter
+        </button>
+      )}
+      <span className="ml-2 text-sm text-text-muted">{Math.round(percent)}%</span>
+    </div>
     <div className="flex-1 text-center truncate">{title}</div>
-    <button
-      onClick={() => onFontSize(1)}
-      aria-label="Increase font"
-      className="px-[var(--space-2)]"
-    >
-      A+
-    </button>
-    <button
-      onClick={() => onFontSize(-1)}
-      aria-label="Decrease font"
-      className="px-[var(--space-2)]"
-    >
-      A-
-    </button>
-    <button onClick={onToggleTheme} aria-label="Toggle theme" className="px-[var(--space-2)]">
-      Theme
-    </button>
-    <button
-      onClick={() => {
-        logEvent('click_fav');
-        onBookmark();
-      }}
-      aria-label="Bookmark"
-      className="px-[var(--space-2)]"
-    >
-      ★
-    </button>
-    <span className="ml-2 text-sm text-text-muted">{Math.round(percent)}%</span>
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => onFontSize(1)}
+        aria-label="Increase font"
+        className="px-[var(--space-2)]"
+      >
+        A+
+      </button>
+      <button
+        onClick={() => onFontSize(-1)}
+        aria-label="Decrease font"
+        className="px-[var(--space-2)]"
+      >
+        A-
+      </button>
+      <button onClick={onToggleTheme} aria-label="Toggle theme" className="px-[var(--space-2)]">
+        Theme
+      </button>
+      <button
+        onClick={() => {
+          logEvent('click_fav');
+          onBookmark();
+        }}
+        aria-label="Bookmark"
+        className="px-[var(--space-2)]"
+      >
+        ★
+      </button>
+    </div>
   </div>
 );

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -60,19 +60,26 @@ export const ReaderScreen: React.FC = () => {
 
   if (!bookId) return null;
 
+  const navProps =
+    chapters.length > 1
+      ? {
+          onPrev: () => setIdx((i) => Math.max(0, i - 1)),
+          onNext: () => setIdx((i) => Math.min(chapters.length - 1, i + 1)),
+          hasPrev: idx > 0,
+          hasNext: idx < chapters.length - 1,
+        }
+      : {};
+
   return (
     <div className="flex h-full flex-col">
       <ReaderToolbar
         title={title}
-        percent={Math.round(percent)}
+        percent={percent}
         onBack={() => navigate(-1)}
         onToggleTheme={() => setTheme(theme === 'dark' ? 'default' : 'dark')}
         onFontSize={handleFontSize}
         onBookmark={() => {}}
-        onPrev={() => setIdx((i) => Math.max(0, i - 1))}
-        onNext={() => setIdx((i) => Math.min(chapters.length - 1, i + 1))}
-        hasPrev={idx > 0}
-        hasNext={idx < chapters.length - 1}
+        {...navProps}
       />
       <ProgressBar value={percent} aria-label="Reading progress" />
       <ReaderView
@@ -85,7 +92,15 @@ export const ReaderScreen: React.FC = () => {
         className="flex-1"
         style={{ fontSize }}
       />
-      <div className="p-[var(--space-4)]">
+      <div className="p-[var(--space-4)] flex flex-col gap-[var(--space-4)]">
+        {idx < chapters.length - 1 && percent >= 100 && (
+          <Button
+            onClick={() => setIdx((i) => Math.min(chapters.length - 1, i + 1))}
+            className="w-full px-3 py-2"
+          >
+            Next Chapter
+          </Button>
+        )}
         <Button
           onClick={() => {
             finishBook(bookId);


### PR DESCRIPTION
## Summary
- show reader progress percentage beside navigation controls
- conditionally wire up next/prev actions for multi-chapter books
- allow advancing to subsequent chapters with a Next Chapter button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d86d8f9748331a5c5482c4c66a7a0