### PR TITLE
Add ReactionContext and react-query integration for reactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
+        "@tanstack/react-query": "^5.60.2",
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.2.6",
         "express": "^4.21.2",
@@ -60,6 +61,9 @@
         "typescript": "^5.8.3",
         "vite": "^5.2.0",
         "vite-plugin-pwa": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4116,6 +4120,32 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
+      "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.84.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.84.1.tgz",
+      "integrity": "sha512-zo7EUygcWJMQfFNWDSG7CBhy8irje/XY0RDVKKV4IQJAysb+ZJkkJPcnQi+KboyGUgT+SQebRFoTqLuTtfoDLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "workbox-precaching": "^7.3.0",
     "workbox-routing": "^7.3.0",
     "workbox-strategies": "^7.3.0",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "@tanstack/react-query": "^5.60.2"
   }
 }

--- a/src/contexts/ReactionContext.tsx
+++ b/src/contexts/ReactionContext.tsx
@@ -1,0 +1,112 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from 'react';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useNostr } from '../nostr';
+import { publishVote, publishFavourite } from '../nostr/events';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+interface ReactionState {
+  count: number;
+  active: boolean;
+}
+
+interface ReactionContextValue {
+  reactToContent: (
+    target: string,
+    type: 'vote' | 'favourite',
+  ) => Promise<void>;
+}
+
+const ReactionContext = createContext<ReactionContextValue | undefined>(
+  undefined,
+);
+
+export const useReactionContext = () => {
+  const ctx = useContext(ReactionContext);
+  if (!ctx) throw new Error('useReactionContext must be used within ReactionProvider');
+  return ctx;
+};
+
+const queryClient = new QueryClient();
+
+export const ReactionProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const nostr = useNostr();
+
+  const reactToContent = useCallback(
+    async (target: string, type: 'vote' | 'favourite') => {
+      if (type === 'vote') {
+        await publishVote(nostr, target);
+      } else {
+        await publishFavourite(nostr, target);
+      }
+      queryClient.invalidateQueries({ queryKey: ['reaction', type, target] });
+    },
+    [nostr],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ReactionContext.Provider value={{ reactToContent }}>
+        {children}
+      </ReactionContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+export function useReactions(target: string, type: 'vote' | 'favourite') {
+  const nostr = useNostr();
+  const queryClient = useQueryClient();
+  const idsRef = useRef<Set<string>>(new Set());
+  const symbol = type === 'vote' ? '+' : '★';
+
+  const query = useQuery<ReactionState>({
+    queryKey: ['reaction', type, target],
+    queryFn: async () => {
+      const events = await nostr.list([{ kinds: [7], '#e': [target] }]);
+      const ids = new Set<string>();
+      let count = 0;
+      let active = false;
+      for (const evt of events as NostrEvent[]) {
+        if (evt.content === symbol && !ids.has(evt.id)) {
+          ids.add(evt.id);
+          count++;
+          if (evt.pubkey === nostr.pubkey) active = true;
+        }
+      }
+      idsRef.current = ids;
+      return { count, active };
+    },
+    initialData: { count: 0, active: false },
+  });
+
+  useEffect(() => {
+    const off = nostr.subscribe([{ kinds: [7], '#e': [target] }], (evt: NostrEvent) => {
+      if (evt.content === symbol && !idsRef.current.has(evt.id)) {
+        idsRef.current.add(evt.id);
+        queryClient.setQueryData<ReactionState>(
+          ['reaction', type, target],
+          (old) => ({
+            count: (old?.count ?? 0) + 1,
+            active: old?.active || evt.pubkey === nostr.pubkey,
+          }),
+        );
+      }
+    });
+    return off;
+  }, [nostr, target, type, queryClient, symbol]);
+
+  return query;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,14 +8,17 @@ import { App } from './index';
 import { registerServiceWorker } from './registerSw';
 import { NostrProvider } from './nostr';
 import { WalletProvider } from './WalletConnect';
+import { ReactionProvider } from './contexts/ReactionContext';
 
 const rootEl = document.getElementById('root');
 if (rootEl) {
   createRoot(rootEl).render(
     <NostrProvider>
-      <WalletProvider>
-        <App />
-      </WalletProvider>
+      <ReactionProvider>
+        <WalletProvider>
+          <App />
+        </WalletProvider>
+      </ReactionProvider>
     </NostrProvider>,
   );
 }

--- a/test/reactionButtonToast.test.js
+++ b/test/reactionButtonToast.test.js
@@ -18,6 +18,8 @@ const path = require('path');
       'react-icons/fa',
       './src/nostr.tsx','./src/nostr/events.ts',
       './src/components/ToastProvider.tsx',
+      './src/contexts/ReactionContext.tsx',
+      '@tanstack/react-query',
       'nostr-tools',
     ],
   });
@@ -38,6 +40,19 @@ const path = require('path');
         if (p === "./src/components/ToastProvider.tsx") {
           return { useToast: () => (msg) => calls.push(msg) };
         }
+      if (p === './src/contexts/ReactionContext.tsx') {
+        return {
+          useReactions: () => ({ data: { count: 0, active: false } }),
+          useReactionContext: () => ({
+            reactToContent: async () => {
+              throw new Error('fail');
+            },
+          }),
+        };
+      }
+      if (p === '@tanstack/react-query') {
+        return { useQueryClient: () => ({ setQueryData() {}, invalidateQueries() {} }) };
+      }
       if (p === 'react-icons/fa') {
         return { FaThumbsUp: () => React.createElement('div'), FaStar: () => React.createElement('div') };
       }


### PR DESCRIPTION
## Summary
- add ReactionContext with react-query caching and ReactionProvider
- wrap app with ReactionProvider
- refactor ReactionButton to use new context and cached reactions
- stub ReactionContext in tests and add react-query dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8f9ac4c08331b31598ae3961ccfb