### PR TITLE
Add stats page with reading and rating charts

### DIFF
--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export interface StatsCardsProps {
+  total: number;
+  finished: number;
+  reading: number;
+  want: number;
+}
+
+/**
+ * Displays summary cards for reading stats.
+ */
+export const StatsCards: React.FC<StatsCardsProps> = ({
+  total,
+  finished,
+  reading,
+  want,
+}) => (
+  <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+    <div className="rounded border p-4 text-center">
+      <p className="text-2xl font-semibold">{total}</p>
+      <p className="text-sm text-text-muted">Total</p>
+    </div>
+    <div className="rounded border p-4 text-center">
+      <p className="text-2xl font-semibold">{finished}</p>
+      <p className="text-sm text-text-muted">Finished</p>
+    </div>
+    <div className="rounded border p-4 text-center">
+      <p className="text-2xl font-semibold">{reading}</p>
+      <p className="text-sm text-text-muted">Reading</p>
+    </div>
+    <div className="rounded border p-4 text-center">
+      <p className="text-2xl font-semibold">{want}</p>
+      <p className="text-sm text-text-muted">Want to Read</p>
+    </div>
+  </div>
+);

--- a/src/components/StatsCharts.tsx
+++ b/src/components/StatsCharts.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+interface StatusChartProps {
+  finished: number;
+  reading: number;
+  want: number;
+}
+
+export const StatusChart: React.FC<StatusChartProps> = ({ finished, reading, want }) => {
+  const total = finished + reading + want;
+  const makeWidth = (n: number) => `${total ? (n / total) * 100 : 0}%`;
+  return (
+    <div className="space-y-2">
+      {[['Finished', finished], ['Reading', reading], ['Want', want]].map(([label, value]) => (
+        <div key={label as string} className="flex items-center gap-2">
+          <span className="w-16 text-sm">{label}</span>
+          <div className="flex-1 h-2 rounded bg-gray-200">
+            <div
+              className="h-2 rounded bg-[color:var(--clr-primary-600)]"
+              style={{ width: makeWidth(value as number) }}
+            />
+          </div>
+          <span className="w-8 text-right text-sm">{value as number}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+interface RatingChartProps {
+  ratings: Record<number, number>;
+  total: number;
+}
+
+export const RatingChart: React.FC<RatingChartProps> = ({ ratings, total }) => {
+  const makeWidth = (n: number) => `${total ? (n / total) * 100 : 0}%`;
+  return (
+    <div className="space-y-2">
+      {[5, 4, 3, 2, 1].map((r) => (
+        <div key={r} className="flex items-center gap-2">
+          <span className="w-16 text-sm">{r}★</span>
+          <div className="flex-1 h-2 rounded bg-gray-200">
+            <div
+              className="h-2 rounded bg-[color:var(--clr-primary-600)]"
+              style={{ width: makeWidth(ratings[r] || 0) }}
+            />
+          </div>
+          <span className="w-8 text-right text-sm">{ratings[r] || 0}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/hooks/useStatsData.ts
+++ b/src/hooks/useStatsData.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import type { Event as NostrEvent } from 'nostr-tools';
+import { useNostr } from '../nostr';
+
+export interface StatsData {
+  total: number;
+  finished: number;
+  reading: number;
+  want: number;
+  ratings: Record<number, number>;
+}
+
+const initialRatings: Record<number, number> = {
+  1: 0,
+  2: 0,
+  3: 0,
+  4: 0,
+  5: 0,
+};
+
+/**
+ * Hook fetching reading history and rating distribution from the user's
+ * Nostr lists.
+ */
+export function useStatsData(): StatsData {
+  const { pubkey, list } = useNostr();
+  const [data, setData] = useState<StatsData>({
+    total: 0,
+    finished: 0,
+    reading: 0,
+    want: 0,
+    ratings: initialRatings,
+  });
+
+  useEffect(() => {
+    if (!pubkey) return;
+    (async () => {
+      try {
+        const evts = (await list([
+          { kinds: [30001], authors: [pubkey], '#d': ['library'], limit: 1 },
+          { kinds: [30001], authors: [pubkey], '#d': ['ratings'], limit: 1 },
+        ])) as NostrEvent[];
+        const library = evts.find((e) =>
+          e.tags.some((t) => t[0] === 'd' && t[1] === 'library'),
+        );
+        const ratingsEvt = evts.find((e) =>
+          e.tags.some((t) => t[0] === 'd' && t[1] === 'ratings'),
+        );
+        const stats = { total: 0, finished: 0, reading: 0, want: 0 };
+        const ratings = { ...initialRatings };
+        if (library) {
+          library.tags
+            .filter((t) => t[0] === 'e')
+            .forEach((t) => {
+              stats.total += 1;
+              const status = t[2] || 'want';
+              if (status === 'finished') stats.finished += 1;
+              else if (status === 'reading') stats.reading += 1;
+              else stats.want += 1;
+            });
+        }
+        if (ratingsEvt) {
+          ratingsEvt.tags
+            .filter((t) => t[0] === 'e')
+            .forEach((t) => {
+              const rating = parseInt(t[2] || '', 10);
+              if (rating >= 1 && rating <= 5) ratings[rating] += 1;
+            });
+        }
+        setData({ ...stats, ratings });
+      } catch {
+        setData({ total: 0, finished: 0, reading: 0, want: 0, ratings: initialRatings });
+      }
+    })();
+  }, [pubkey, list]);
+
+  return data;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,7 @@ import UISettingsPage from './pages/UISettings';
 import OfflineSettingsPage from './pages/OfflineSettings';
 import RelaySettingsPage from './pages/RelaySettings';
 import SettingsHome from './pages/SettingsHome';
+import StatsPage from './pages/Stats';
 import { ProfileScreen } from './screens/ProfileScreen';
 import { ToastProvider } from './components/ToastProvider';
 
@@ -126,6 +127,7 @@ const AppRoutes: React.FC = () => (
       <Route path="settings/offline" element={<OfflineSettingsPage />} />
       <Route path="settings/relays" element={<RelaySettingsPage />} />
       <Route path="profile/settings" element={<Navigate replace to="/settings/profile" />} />
+      <Route path="stats" element={<StatsPage />} />
       <Route path="books" element={<BookListScreen />} />
       <Route path="book/:bookId" element={<BookDetailScreen />} />
       <Route path="book/:bookId/chapters" element={<ManageChaptersPage />} />

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StatsCards } from '../components/StatsCards';
+import { StatusChart, RatingChart } from '../components/StatsCharts';
+import { useStatsData } from '../hooks/useStatsData';
+
+const StatsPage: React.FC = () => {
+  const { total, finished, reading, want, ratings } = useStatsData();
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Stats</h1>
+      <StatsCards total={total} finished={finished} reading={reading} want={want} />
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">Reading Status</h2>
+        <StatusChart finished={finished} reading={reading} want={want} />
+      </div>
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">Ratings</h2>
+        <RatingChart ratings={ratings} total={total} />
+      </div>
+    </div>
+  );
+};
+
+export default StatsPage;

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -175,7 +175,10 @@ export const ProfileScreen: React.FC = () => {
         )}
       </ul>
       {pubkey === loggedPubkey && (
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          <Link to="/stats" className="rounded border px-2 py-1">
+            Stats
+          </Link>
           <Link to="/lists/new" className="rounded border px-2 py-1">
             Create List
           </Link>


### PR DESCRIPTION
## Summary
- Add Stats page with cards and charts for reading status and ratings
- Fetch stats from Nostr lists via new `useStatsData` hook
- Link stats into profile navigation and app routing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d910158f08331845be4afe7e11496