### PR TITLE
feat: add desktop navigation

### DIFF
--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { FaCompass, FaBookOpen, FaPen, FaBell, FaUser, FaHome } from 'react-icons/fa';
+import type { IconType } from 'react-icons';
+import { useNotificationStore } from '../store/notifications';
+
+// Navigation key type shared with BottomNav
+export type NavKey = 'home' | 'discover' | 'library' | 'write' | 'activity' | 'profile';
+
+export interface SideNavProps {
+  active: NavKey;
+  onChange: (key: NavKey) => void;
+  className?: string;
+  'data-testid'?: string;
+}
+
+const items: Array<{ key: NavKey; label: string; Icon: IconType }> = [
+  { key: 'home', label: 'Home', Icon: FaHome },
+  { key: 'discover', label: 'Discover', Icon: FaCompass },
+  { key: 'library', label: 'Library', Icon: FaBookOpen },
+  { key: 'write', label: 'Write', Icon: FaPen },
+  { key: 'activity', label: 'Activity', Icon: FaBell },
+  { key: 'profile', label: 'Profile', Icon: FaUser },
+];
+
+/**
+ * Side navigation bar for larger viewports. Mirrors BottomNav behaviour.
+ */
+export const SideNav: React.FC<SideNavProps> = ({
+  active,
+  onChange,
+  className,
+  'data-testid': dataTestId,
+}) => {
+  const unseen = useNotificationStore((s) => s.unseen.length);
+  return (
+    <nav
+      className={`flex flex-col w-48 border-r bg-[color:var(--clr-surface-alt)] ${className ?? ''}`}
+      data-testid={dataTestId}
+    >
+      {items.map(({ key, label, Icon }) => (
+        <button
+          type="button"
+          key={key}
+          onClick={() => onChange(key)}
+          aria-pressed={active === key}
+          aria-label={label}
+          className="flex items-center gap-2 p-[var(--space-2)] text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+        >
+          <span className="relative">
+            <Icon className="text-xl" aria-hidden="true" />
+            {key === 'activity' && unseen > 0 && (
+              <span className="absolute -top-1 -right-2 rounded-full bg-red-600 px-1 text-[10px] leading-none text-white">
+                {unseen}
+              </span>
+            )}
+          </span>
+          <span>{label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+};
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import { Header } from './components/Header';
 import { LoginModal } from './components/LoginModal';
 import { search, Suggestion } from './search';
 import { BottomNav } from './components/BottomNav';
+import { SideNav } from './components/SideNav';
 import { ThemeProvider } from './ThemeProvider';
 import { DMModal } from './components/DMModal';
 import { useNostr } from './nostr';
@@ -98,10 +99,19 @@ const Layout: React.FC = () => {
           💬
         </button>
       </Header>
-      <main id="main" className="p-[var(--space-4)]">
-        <Outlet />
-      </main>
-      <BottomNav active={active} onChange={handleChange} />
+      <div className="flex">
+        <SideNav
+          active={active}
+          onChange={handleChange}
+          className="hidden md:flex"
+        />
+        <main id="main" className="flex-1 p-[var(--space-4)]">
+          <Outlet />
+        </main>
+      </div>
+      <div className="md:hidden">
+        <BottomNav active={active} onChange={handleChange} />
+      </div>
       {chatOpen && contacts[0] && (
         <DMModal to={contacts[0]} onClose={() => setChatOpen(false)} />
       )}


### PR DESCRIPTION
## Summary
- add SideNav for larger screens and hide BottomNav on desktop
- wire side navigation into main layout with responsive styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d97b9095883319e454442231e0545