### PR TITLE
feat: add desktop tag sidebar

### DIFF
--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -9,6 +9,7 @@ import { OnboardingTooltip } from './OnboardingTooltip';
 import { logEvent } from '../analytics';
 import { CommunityFeed } from './CommunityFeed';
 import { Illustration } from './Illustration';
+import { TagSidebar } from './TagSidebar';
 
 /**
  * Discover books with search and trending lists.
@@ -103,101 +104,108 @@ export const Discover: React.FC = () => {
           </div>
         </OnboardingTooltip>
       </header>
-      <div className="flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]">
-        {tagOptions.map((t) => (
-          <button
-            key={t}
-            onClick={() => setTag(t)}
-            aria-pressed={tag === t}
-            aria-label={t}
-            className={`btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] ${
-              tag === t
-                ? 'bg-[color:var(--clr-primary-600)] text-white'
-                : 'border border-border text-[color:var(--clr-primary-600)] bg-[color:var(--clr-surface)]'
-            }`}
-          >
-            {t}
-          </button>
-        ))}
+      <div className="md:flex">
+        <TagSidebar
+          tags={tagOptions}
+          selectedTag={tag}
+          onSelect={(t) => setTag(t)}
+        />
+        <div className="flex-1">
+          <div className="md:hidden flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]">
+            {tagOptions.map((t) => (
+              <button
+                key={t}
+                onClick={() => setTag(t)}
+                aria-pressed={tag === t}
+                aria-label={t}
+                className={`btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] ${
+                  tag === t
+                    ? 'bg-[color:var(--clr-primary-600)] text-white'
+                    : 'border border-border text-[color:var(--clr-primary-600)] bg-[color:var(--clr-surface)]'
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+          <section className="p-[var(--space-4)]">
+            <h2 className="mb-[var(--space-2)] font-semibold">Trending Books</h2>
+            <ul
+              role="list"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+            >
+              {loading && trending.length === 0
+                ? Array.from({ length: 6 }).map((_, i) => (
+                    <li key={i} role="listitem">
+                      <BookCardSkeleton />
+                    </li>
+                  ))
+                : trending.map((e) => (
+                    <li key={e.id} role="listitem">
+                      <BookCard
+                        event={e as NostrEvent}
+                        onDelete={(id) => removeBook(id)}
+                      />
+                    </li>
+                  ))}
+            </ul>
+          </section>
+          <section className="p-[var(--space-4)]">
+            <h2 className="mb-[var(--space-2)] font-semibold">New Releases</h2>
+            <ul
+              role="list"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+            >
+              {loading && newReleases.length === 0
+                ? Array.from({ length: 6 }).map((_, i) => (
+                    <li key={i} role="listitem">
+                      <BookCardSkeleton />
+                    </li>
+                  ))
+                : newReleases.map((e) => (
+                    <li key={e.id} role="listitem">
+                      <BookCard
+                        event={e as NostrEvent}
+                        onDelete={(id) => removeBook(id)}
+                      />
+                    </li>
+                  ))}
+            </ul>
+          </section>
+          <section className="p-[var(--space-4)]">
+            <h2 className="mb-[var(--space-2)] font-semibold">Recommended for You</h2>
+            <ul
+              role="list"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+            >
+              {noResults ? (
+                <div className="col-span-full">
+                  <Illustration text="No matching books found." />
+                </div>
+              ) : loading && recommended.length === 0 ? (
+                Array.from({ length: 6 }).map((_, i) => (
+                  <li key={i} role="listitem">
+                    <BookCardSkeleton />
+                  </li>
+                ))
+              ) : (
+                recommended.map((e) => (
+                  <li key={e.id} role="listitem">
+                    <BookCard
+                      event={e as NostrEvent}
+                      onDelete={(id) => removeBook(id)}
+                    />
+                  </li>
+                ))
+              )}
+            </ul>
+          </section>
+          <section className="p-[var(--space-4)]">
+            <h2 className="mb-[var(--space-2)] font-semibold">Communities</h2>
+            <CommunityFeed />
+          </section>
+        </div>
       </div>
-      <section className="p-[var(--space-4)]">
-        <h2 className="mb-[var(--space-2)] font-semibold">Trending Books</h2>
-        <ul
-          role="list"
-          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-        >
-          {loading && trending.length === 0
-            ? Array.from({ length: 6 }).map((_, i) => (
-                <li key={i} role="listitem">
-                  <BookCardSkeleton />
-                </li>
-              ))
-            : trending.map((e) => (
-                <li key={e.id} role="listitem">
-                  <BookCard
-                    event={e as NostrEvent}
-                    onDelete={(id) => removeBook(id)}
-                  />
-                </li>
-              ))}
-        </ul>
-      </section>
-      <section className="p-[var(--space-4)]">
-        <h2 className="mb-[var(--space-2)] font-semibold">New Releases</h2>
-        <ul
-          role="list"
-          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-        >
-          {loading && newReleases.length === 0
-            ? Array.from({ length: 6 }).map((_, i) => (
-                <li key={i} role="listitem">
-                  <BookCardSkeleton />
-                </li>
-              ))
-            : newReleases.map((e) => (
-                <li key={e.id} role="listitem">
-                  <BookCard
-                    event={e as NostrEvent}
-                    onDelete={(id) => removeBook(id)}
-                  />
-                </li>
-              ))}
-        </ul>
-      </section>
-      <section className="p-[var(--space-4)]">
-        <h2 className="mb-[var(--space-2)] font-semibold">
-          Recommended for You
-        </h2>
-        <ul
-          role="list"
-          className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-        >
-          {noResults ? (
-            <div className="col-span-full">
-              <Illustration text="No matching books found." />
-            </div>
-          ) : loading && recommended.length === 0 ? (
-            Array.from({ length: 6 }).map((_, i) => (
-              <li key={i} role="listitem">
-                <BookCardSkeleton />
-              </li>
-            ))
-          ) : (
-            recommended.map((e) => (
-              <li key={e.id} role="listitem">
-                <BookCard
-                  event={e as NostrEvent}
-                  onDelete={(id) => removeBook(id)}
-                />
-              </li>
-            ))
-          )}
-        </ul>
-      </section>
-      <section className="p-[var(--space-4)]">
-        <h2 className="mb-[var(--space-2)] font-semibold">Communities</h2>
-        <CommunityFeed />
-      </section>
     </div>
   );
 };

--- a/src/components/TagSidebar.tsx
+++ b/src/components/TagSidebar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface TagSidebarProps {
+  tags: string[];
+  selectedTag: string;
+  onSelect: (tag: string) => void;
+}
+
+export const TagSidebar: React.FC<TagSidebarProps> = ({
+  tags,
+  selectedTag,
+  onSelect,
+}) => (
+  <aside className="hidden md:block md:w-48 p-[var(--space-4)]">
+    <ul className="flex flex-col gap-[var(--space-2)]">
+      {tags.map((t) => (
+        <li key={t}>
+          <button
+            onClick={() => onSelect(t)}
+            aria-pressed={selectedTag === t}
+            aria-label={t}
+            className={`btn-tap w-full text-left rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] ${
+              selectedTag === t
+                ? 'bg-[color:var(--clr-primary-600)] text-white'
+                : 'border border-border text-[color:var(--clr-primary-600)] bg-[color:var(--clr-surface)]'
+            }`}
+          >
+            {t}
+          </button>
+        </li>
+      ))}
+    </ul>
+  </aside>
+);
+
+export default TagSidebar;

--- a/test/jest/__snapshots__/Discover.test.tsx.snap
+++ b/test/jest/__snapshots__/Discover.test.tsx.snap
@@ -28,68 +28,93 @@ exports[`Discover desktop snapshot 1`] = `
     </div>
   </header>
   <div
-    class="flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+    class="md:flex"
   >
-    <button
-      aria-label="All"
-      aria-pressed="true"
-      class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+    <aside
+      class="hidden md:block md:w-48 p-[var(--space-4)]"
     >
-      All
-    </button>
+      <ul
+        class="flex flex-col gap-[var(--space-2)]"
+      >
+        <li>
+          <button
+            aria-label="All"
+            aria-pressed="true"
+            class="btn-tap w-full text-left rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+          >
+            All
+          </button>
+        </li>
+      </ul>
+    </aside>
+    <div
+      class="flex-1"
+    >
+      <div
+        class="md:hidden flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+      >
+        <button
+          aria-label="All"
+          aria-pressed="true"
+          class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+        >
+          All
+        </button>
+      </div>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Trending Books
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          New Releases
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Recommended for You
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Communities
+        </h2>
+        <ul
+          class="space-y-4"
+          role="list"
+        />
+      </section>
+    </div>
   </div>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Trending Books
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      New Releases
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Recommended for You
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Communities
-    </h2>
-    <ul
-      class="space-y-4"
-      role="list"
-    />
-  </section>
 </div>
 `;
 
@@ -121,67 +146,92 @@ exports[`Discover mobile snapshot 1`] = `
     </div>
   </header>
   <div
-    class="flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+    class="md:flex"
   >
-    <button
-      aria-label="All"
-      aria-pressed="true"
-      class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+    <aside
+      class="hidden md:block md:w-48 p-[var(--space-4)]"
     >
-      All
-    </button>
+      <ul
+        class="flex flex-col gap-[var(--space-2)]"
+      >
+        <li>
+          <button
+            aria-label="All"
+            aria-pressed="true"
+            class="btn-tap w-full text-left rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+          >
+            All
+          </button>
+        </li>
+      </ul>
+    </aside>
+    <div
+      class="flex-1"
+    >
+      <div
+        class="md:hidden flex overflow-x-auto gap-[var(--space-2)] px-[var(--space-2)] pb-[var(--space-2)]"
+      >
+        <button
+          aria-label="All"
+          aria-pressed="true"
+          class="btn-tap whitespace-nowrap rounded-[var(--radius-button)] px-[var(--space-2)] py-[var(--space-1)] text-[14px] bg-[color:var(--clr-primary-600)] text-white"
+        >
+          All
+        </button>
+      </div>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Trending Books
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          New Releases
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Recommended for You
+        </h2>
+        <ul
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          role="list"
+        />
+      </section>
+      <section
+        class="p-[var(--space-4)]"
+      >
+        <h2
+          class="mb-[var(--space-2)] font-semibold"
+        >
+          Communities
+        </h2>
+        <ul
+          class="space-y-4"
+          role="list"
+        />
+      </section>
+    </div>
   </div>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Trending Books
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      New Releases
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Recommended for You
-    </h2>
-    <ul
-      class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
-      role="list"
-    />
-  </section>
-  <section
-    class="p-[var(--space-4)]"
-  >
-    <h2
-      class="mb-[var(--space-2)] font-semibold"
-    >
-      Communities
-    </h2>
-    <ul
-      class="space-y-4"
-      role="list"
-    />
-  </section>
 </div>
 `;


### PR DESCRIPTION
## Summary
- add vertical `TagSidebar` component for desktop
- hide horizontal tag scroller on larger screens
- keep tag selection in sync across layouts

## Testing
- `npm test`
- `npx jest test/jest/Discover.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688d9a625d388331875ebf63535b68bc