### PR TITLE
feat: expand discover grids for xl screens

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -67,7 +67,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
   };
 
   return (
-    <div className="rounded-[var(--radius-card)] border p-[var(--space-2)]">
+    <div className="rounded-[var(--radius-card)] border p-[var(--space-2)] xl:p-[var(--space-1)]">
       {event.repostedBy && (
         <p className="mb-[var(--space-1)] text-xs text-text-muted">
           Reposted by {event.repostedBy}
@@ -77,7 +77,7 @@ export const BookCard: React.FC<BookCardProps> = ({ event, onDelete }) => {
         <img
           src={cover}
           alt={`Cover image for ${title}`}
-          className="mb-[var(--space-2)] h-32 w-24 object-cover"
+          className="mb-[var(--space-2)] h-32 w-24 object-cover xl:h-28 xl:w-20"
         />
       )}
       <h3 className="font-semibold">{title}</h3>

--- a/src/components/BookCardSkeleton.tsx
+++ b/src/components/BookCardSkeleton.tsx
@@ -5,8 +5,8 @@ import { Skeleton, TextSkeleton } from './Skeleton';
  * Placeholder skeleton displayed while book content loads.
  */
 export const BookCardSkeleton: React.FC = () => (
-  <div className="rounded-[var(--radius-card)] border p-[var(--space-2)] space-y-[var(--space-2)]">
-    <Skeleton className="h-32 w-24" />
+  <div className="rounded-[var(--radius-card)] border p-[var(--space-2)] xl:p-[var(--space-1)] space-y-[var(--space-2)]">
+    <Skeleton className="h-32 w-24 xl:h-28 xl:w-20" />
     <TextSkeleton lines={1} className="w-3/4" />
     <TextSkeleton lines={1} />
     <div className="pt-2 flex gap-2">

--- a/src/components/Discover.tsx
+++ b/src/components/Discover.tsx
@@ -83,7 +83,7 @@ export const Discover: React.FC = () => {
 
   return (
     <div className="pb-[var(--space-4)]">
-      <header className="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)]">
+      <header className="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)] lg:p-[var(--space-2)]">
         <h1 className="text-[18px] font-semibold text-white">Bookstr</h1>
         <OnboardingTooltip storageKey="discover-search" text="Search for books">
           <div className="flex flex-1 items-center gap-1">
@@ -132,7 +132,7 @@ export const Discover: React.FC = () => {
             <h2 className="mb-[var(--space-2)] font-semibold">Trending Books</h2>
             <ul
               role="list"
-              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
             >
               {loading && trending.length === 0
                 ? Array.from({ length: 6 }).map((_, i) => (
@@ -154,7 +154,7 @@ export const Discover: React.FC = () => {
             <h2 className="mb-[var(--space-2)] font-semibold">New Releases</h2>
             <ul
               role="list"
-              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
             >
               {loading && newReleases.length === 0
                 ? Array.from({ length: 6 }).map((_, i) => (
@@ -176,7 +176,7 @@ export const Discover: React.FC = () => {
             <h2 className="mb-[var(--space-2)] font-semibold">Recommended for You</h2>
             <ul
               role="list"
-              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+              className="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
             >
               {noResults ? (
                 <div className="col-span-full">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -60,7 +60,7 @@ export const Header: React.FC<HeaderProps> = ({
         <button
           onClick={() => navigate(-1)}
           aria-label="Back"
-          className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className="p-2 lg:p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
         >
           <FaChevronLeft />
         </button>
@@ -70,7 +70,7 @@ export const Header: React.FC<HeaderProps> = ({
           e.preventDefault();
           onSelectSuggestion?.(q, 'search');
         }}
-        className="flex items-center gap-2 p-2"
+        className="flex items-center gap-2 p-2 lg:p-1"
       >
         <input
           value={q}
@@ -110,7 +110,7 @@ export const Header: React.FC<HeaderProps> = ({
       {onLogin && (
         <button
           onClick={onLogin}
-          className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className="p-2 lg:p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
         >
           Login
         </button>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -146,7 +146,7 @@ export const Library: React.FC = () => {
           ))}
         </div>
       )}
-      <div className="mt-[var(--space-4)] grid gap-4 lg:grid-cols-4">
+      <div className="mt-[var(--space-4)] grid gap-4 lg:grid-cols-4 xl:grid-cols-6">
         {groups.map((g) => (
           <section
             key={g.key}

--- a/test/discoverGridLayout.test.js
+++ b/test/discoverGridLayout.test.js
@@ -78,6 +78,7 @@ const path = require('path');
     const cls = g.props.className;
     assert.ok(cls.includes('md:grid-cols-2'), 'md:grid-cols-2 missing');
     assert.ok(cls.includes('lg:grid-cols-4'), 'lg:grid-cols-4 missing');
+    assert.ok(cls.includes('xl:grid-cols-6'), 'xl:grid-cols-6 missing');
   });
   console.log('All tests passed.');
 })();

--- a/test/jest/__snapshots__/Discover.test.tsx.snap
+++ b/test/jest/__snapshots__/Discover.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Discover desktop snapshot 1`] = `
   class="pb-[var(--space-4)]"
 >
   <header
-    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)]"
+    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)] lg:p-[var(--space-2)]"
   >
     <h1
       class="text-[18px] font-semibold text-white"
@@ -70,7 +70,7 @@ exports[`Discover desktop snapshot 1`] = `
           Trending Books
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>
@@ -83,7 +83,7 @@ exports[`Discover desktop snapshot 1`] = `
           New Releases
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>
@@ -96,7 +96,7 @@ exports[`Discover desktop snapshot 1`] = `
           Recommended for You
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>
@@ -123,7 +123,7 @@ exports[`Discover mobile snapshot 1`] = `
   class="pb-[var(--space-4)]"
 >
   <header
-    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)]"
+    class="flex items-center gap-[var(--space-2)] bg-[color:var(--clr-primary-600)] p-[var(--space-3)] lg:p-[var(--space-2)]"
   >
     <h1
       class="text-[18px] font-semibold text-white"
@@ -188,7 +188,7 @@ exports[`Discover mobile snapshot 1`] = `
           Trending Books
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>
@@ -201,7 +201,7 @@ exports[`Discover mobile snapshot 1`] = `
           New Releases
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>
@@ -214,7 +214,7 @@ exports[`Discover mobile snapshot 1`] = `
           Recommended for You
         </h2>
         <ul
-          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4"
+          class="grid grid-cols-1 gap-[var(--space-4)] md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6"
           role="list"
         />
       </section>


### PR DESCRIPTION
## Summary
- show 6 book cards per row on xl screens
- shrink card padding and cover on xl for readability
- reduce desktop header padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d9c0c412c8331b9bc86091b36562b