### PR TITLE
feat: add desktop banner for login and chat

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -110,7 +110,7 @@ export const Header: React.FC<HeaderProps> = ({
       {onLogin && (
         <button
           onClick={onLogin}
-          className="p-2 lg:p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className="p-2 lg:p-1 md:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
         >
           Login
         </button>

--- a/src/components/PromptBanner.tsx
+++ b/src/components/PromptBanner.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNostr } from '../nostr';
+
+interface PromptBannerProps {
+  onLogin: () => void;
+  onChat: () => void;
+}
+
+/**
+ * Persistent banner with login and chat controls for larger screens.
+ */
+export const PromptBanner: React.FC<PromptBannerProps> = ({ onLogin, onChat }) => {
+  const { pubkey } = useNostr();
+  return (
+    <div className="hidden md:flex sticky top-0 z-40 w-full justify-center gap-[var(--space-3)] bg-[color:var(--clr-surface-alt)] border-b p-[var(--space-2)]">
+      {!pubkey && (
+        <button onClick={onLogin} className="text-sm underline">
+          Sign in
+        </button>
+      )}
+      <button onClick={onChat} className="text-sm underline">
+        Chat
+      </button>
+    </div>
+  );
+};
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ import SettingsHome from './pages/SettingsHome';
 import StatsPage from './pages/Stats';
 import { ProfileScreen } from './screens/ProfileScreen';
 import { ToastProvider } from './components/ToastProvider';
+import { PromptBanner } from './components/PromptBanner';
 
 const Layout: React.FC = () => {
   const navigate = useNavigate();
@@ -85,6 +86,10 @@ const Layout: React.FC = () => {
 
   return (
     <AppShell>
+      <PromptBanner
+        onLogin={() => setLoginOpen(true)}
+        onChat={() => setChatOpen(true)}
+      />
       <Header
         onSearch={handleSearch}
         suggestions={suggestions}
@@ -94,7 +99,7 @@ const Layout: React.FC = () => {
         <button
           onClick={() => setChatOpen(true)}
           aria-label="Chat"
-          className="p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
+          className="p-2 md:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#6B3AF7]/50"
         >
           💬
         </button>


### PR DESCRIPTION
## Summary
- add sticky banner with login and chat controls for desktop viewports
- hide desktop login/chat buttons in header
- retain mobile modal behavior for prompts

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d9f4004708331b3a70294fed9aa79