### PR TITLE
feat: add sidebar layout to book publish wizard

### DIFF
--- a/src/components/BookPublishWizard.tsx
+++ b/src/components/BookPublishWizard.tsx
@@ -5,6 +5,7 @@ import { useToast } from './ToastProvider';
 import { sanitizeHtml } from '../sanitizeHtml';
 import { reportBookPublished } from '../achievements';
 import { logError } from '../lib/logger';
+import { AuthoringLayout } from './AuthoringLayout';
 
 export interface BookPublishWizardProps {
   onPublish?: (id: string) => void;
@@ -35,6 +36,28 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
   const back = () => setStep((s) => Math.max(0, s - 1));
 
   const toast = useToast();
+
+  const steps = ['Details', 'Cover', 'Tags', 'Content', 'Preview'];
+
+  const sidebar = (
+    <ol className="space-y-1">
+      {steps.map((label, i) => (
+        <li key={label}>
+          <button
+            type="button"
+            onClick={() => setStep(i)}
+            className={`w-full text-left ${
+              i === step
+                ? 'font-semibold text-[color:var(--clr-primary-600)]'
+                : 'text-gray-600 hover:underline'
+            }`}
+          >
+            {label}
+          </button>
+        </li>
+      ))}
+    </ol>
+  );
 
   const handlePublish = async () => {
     setPublishing(true);
@@ -93,8 +116,8 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
     }
   };
 
-  return (
-    <div className="space-y-4">
+  const contentNode = (
+    <div className="mx-auto max-w-4xl space-y-4">
       {step === 0 && (
         <div className="space-y-2">
           <input
@@ -160,90 +183,101 @@ export const BookPublishWizard: React.FC<BookPublishWizardProps> = ({
         </div>
       )}
       {step === 3 && (
-        <div className="space-y-2">
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="Markdown content"
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Markdown content"
               className="w-full rounded border p-[var(--space-2)] min-h-[200px]"
-          />
-          <div className="flex justify-between gap-2">
-            <button onClick={back} className="rounded border px-[var(--space-4)] py-[var(--space-2)]">
-              Back
-            </button>
-            <button
-              onClick={next}
+            />
+            <div className="flex justify-between gap-2">
+              <button onClick={back} className="rounded border px-[var(--space-4)] py-[var(--space-2)]">
+                Back
+              </button>
+              <button
+                onClick={next}
                 className="rounded bg-[color:var(--clr-primary-600)] px-[var(--space-4)] py-[var(--space-2)] text-white"
-            >
-              Next
-            </button>
+              >
+                Next
+              </button>
+            </div>
+          </div>
+          <div className="prose max-w-none rounded border p-[var(--space-2)]">
+            <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
           </div>
         </div>
       )}
       {step === 4 && (
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold">{title}</h2>
-          {cover && (
-            <img
-              src={cover}
-              alt={title ? `Cover image for ${title}` : 'Book cover'}
-              className="max-h-40 w-auto"
-            />
-          )}
-          <p>{summary}</p>
-          <div className="flex flex-wrap gap-1">
-            {tags
-              .split(',')
-              .map((t) => t.trim())
-              .filter(Boolean)
-              .map((t) => (
-                <span
-                  key={t}
-                    className="rounded bg-primary-100 px-[var(--space-2)] py-[var(--space-1)] text-sm"
-                >
-                  {t}
-                </span>
-              ))}
-          </div>
-          <div
-              className="prose max-w-none"
-            dangerouslySetInnerHTML={{ __html: previewHtml }}
-          />
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={announce}
-              onChange={(e) => setAnnounce(e.target.checked)}
-            />
-            Post announcement
-          </label>
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={pow}
-              onChange={(e) => setPow(e.target.checked)}
-            />
-            Enable proof-of-work
-          </label>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={announce}
+                onChange={(e) => setAnnounce(e.target.checked)}
+              />
+              Post announcement
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={pow}
+                onChange={(e) => setPow(e.target.checked)}
+              />
+              Enable proof-of-work
+            </label>
             <div className="flex justify-between gap-2">
               <button onClick={back} className="rounded border px-[var(--space-4)] py-[var(--space-2)]">
-              Back
-            </button>
+                Back
+              </button>
               <button
                 onClick={handlePublish}
                 disabled={publishing}
                 className="rounded bg-[color:var(--clr-primary-600)] px-[var(--space-4)] py-[var(--space-2)] text-white disabled:opacity-50"
               >
-              {publishing ? 'Publishing...' : 'Publish'}
-            </button>
-          </div>
-          {publishing && (
+                {publishing ? 'Publishing...' : 'Publish'}
+              </button>
+            </div>
+            {publishing && (
               <div className="flex justify-center pt-[var(--space-2)]">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-[color:var(--clr-primary-600)] border-t-transparent" />
+              </div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold">{title}</h2>
+            {cover && (
+              <img
+                src={cover}
+                alt={title ? `Cover image for ${title}` : 'Book cover'}
+                className="max-h-40 w-auto"
+              />
+            )}
+            <p>{summary}</p>
+            <div className="flex flex-wrap gap-1">
+              {tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter(Boolean)
+                .map((t) => (
+                  <span
+                    key={t}
+                    className="rounded bg-primary-100 px-[var(--space-2)] py-[var(--space-1)] text-sm"
+                  >
+                    {t}
+                  </span>
+                ))}
             </div>
-          )}
+            <div
+              className="prose max-w-none"
+              dangerouslySetInnerHTML={{ __html: previewHtml }}
+            />
+          </div>
         </div>
       )}
     </div>
   );
+
+  return <AuthoringLayout sidebar={sidebar} content={contentNode} />;
 };


### PR DESCRIPTION
## Summary
- use AuthoringLayout for BookPublishWizard with step sidebar
- show content and preview side-by-side for authoring steps
- narrow wizard to max-w-4xl for better readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688da360b4d4833181cc710c2800b0f4