### PR TITLE
Precache editor assets for offline usage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import './designTokens.css';
-@import '@uiw/react-md-editor/dist/mdeditor.css';
-@import '@uiw/react-markdown-preview/dist/markdown.css';
+@import '@uiw/react-md-editor/markdown-editor.css';
+@import '@uiw/react-markdown-preview/markdown.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,6 +3,8 @@
  */
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
+import mdEditorCSS from '@uiw/react-md-editor/markdown-editor.css?url';
+import mdPreviewCSS from '@uiw/react-markdown-preview/markdown.css?url';
 import {
   StaleWhileRevalidate,
   CacheFirst,
@@ -17,7 +19,13 @@ declare let self: ServiceWorkerGlobalScope;
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE || '/api';
 
-precacheAndRoute(self.__WB_MANIFEST || []);
+precacheAndRoute(
+  [
+    ...(self.__WB_MANIFEST || []),
+    { url: mdEditorCSS, revision: null },
+    { url: mdPreviewCSS, revision: null },
+  ],
+);
 
 registerRoute(
   ({ request }) => request.destination === 'image',


### PR DESCRIPTION
## Summary
- include markdown editor styles globally
- precache editor CSS so offline editing works

## Testing
- `npm run build`
- `npm test` *(fails: Cannot import css from @uiw/react-md-editor)*

------
https://chatgpt.com/codex/tasks/task_e_688dc46a8e58833194cceb5dcf3cdfef