### PR TITLE
Handle non NIP-27 relays with versioned copies

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,13 +1,14 @@
 /**
  * Configuration for the API server. Each relay entry defines where published
- * events are forwarded and how much history is retained. Only relays that
- * support NIP‑27 and whose `retentionDays` is at least `prunePolicy.minimumDays`
- * will receive events.
+ * events are forwarded and how much history is retained. Only relays whose
+ * `retentionDays` is at least `prunePolicy.minimumDays` will be considered.
+ * NIP‑27 relays receive the original event while non‑NIP‑27 relays receive
+ * copies suffixed with `-v<nr>` when applicable.
  */
 const relays = [
   { url: 'wss://relay.damus.io', supportsNip27: true, retentionDays: 365 },
   { url: 'wss://relay.primal.net', supportsNip27: true, retentionDays: 30 },
-  { url: 'wss://nostr.wine', supportsNip27: false, retentionDays: 7 },
+  { url: 'wss://nostr.wine', supportsNip27: false, retentionDays: 30 },
 ];
 
 const prunePolicy = {

--- a/test/api_action.test.js
+++ b/test/api_action.test.js
@@ -4,9 +4,9 @@ const { actionHandler, fallbackVersions, pool } = require('../server');
 const { finalizeEvent, generateSecretKey } = require('nostr-tools');
 
 (async () => {
-  let published;
+  let published = [];
   pool.publish = async (_targets, evt) => {
-    published = JSON.parse(JSON.stringify(evt));
+    published.push(JSON.parse(JSON.stringify(evt)));
   };
 
   const res = { json: () => {}, status: () => res, body: null };
@@ -21,15 +21,26 @@ const { finalizeEvent, generateSecretKey } = require('nostr-tools');
 
   await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)), user: { pubkey: baseEvent.pubkey } }, res);
   assert.strictEqual(fallbackVersions['library'], 1);
+  assert.strictEqual(published.length, 2);
   assert.strictEqual(
-    published.tags.find((t) => t[0] === 'd')[1],
+    published[0].tags.find((t) => t[0] === 'd')[1],
+    'library',
+  );
+  assert.strictEqual(
+    published[1].tags.find((t) => t[0] === 'd')[1],
     'library-v1',
   );
 
+  published = [];
   await actionHandler({ body: JSON.parse(JSON.stringify(baseEvent)), user: { pubkey: baseEvent.pubkey } }, res);
   assert.strictEqual(fallbackVersions['library'], 2);
+  assert.strictEqual(published.length, 2);
   assert.strictEqual(
-    published.tags.find((t) => t[0] === 'd')[1],
+    published[0].tags.find((t) => t[0] === 'd')[1],
+    'library',
+  );
+  assert.strictEqual(
+    published[1].tags.find((t) => t[0] === 'd')[1],
     'library-v2',
   );
 


### PR DESCRIPTION
## Summary
- split action relays into NIP-27 and non-NIP-27 targets, cloning events and suffixing `d` tags for non-NIP-27 relays
- treat non-NIP-27 relay as active by meeting retention threshold
- test `actionHandler` to expect two publishes with correct `d` tag versions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8df8199c83318c42dcebe2ffda4f