### PR TITLE
feat: send web push notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.7.1",
         "react-window": "^1.8.11",
+        "web-push": "^3.6.7",
         "workbox-background-sync": "^7.3.0",
         "workbox-expiration": "^7.3.0",
         "workbox-precaching": "^7.3.0",
@@ -5521,7 +5522,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -5786,6 +5786,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -6086,6 +6098,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -6209,6 +6227,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7112,6 +7136,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -9005,6 +9038,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -9039,7 +9081,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11258,6 +11299,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12463,6 +12525,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -12477,6 +12545,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -16859,6 +16936,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js && node test/server_auth.test.js && node test/server_signature.test.js && node test/bookHistory.test.js && node test/useDiscoverBooks.test.js && node test/getListBooks.test.ts && node test/getSearchRelays.test.ts && node test/followedAuthorBackgroundFetch.test.ts && node test/loginClearsSearchCache.test.ts && node test/settings/manageChapters.spec.tsx && node test/settings/offline.spec.tsx && node test/settings/profile.spec.tsx && node test/settings/ui.spec.tsx && node test/settings/relays.spec.tsx && node test/homeFeedFilters.test.ts && node test/publishAnnouncement.test.ts && node test/notificationStore.test.ts && node test/subscriptionPersistence.test.js",
+    "test": "node test/commentUtils.test.js && node test/commentsPlaceholder.test.js && node test/validatePrivKey.test.js && node test/auth.test.js && node test/actions.test.js && node test/registerSw.test.js && node test/bookListScreen.test.js && node test/bookDetailScreen.test.js && node test/bookDetailAuthorFilter.test.js && node test/discoverSearchNoMatch.test.js && node test/bookPublishToast.test.js && node test/bookPublishMeta.test.js && node test/reactionButtonToast.test.js && node test/repostButtonToast.test.js && node test/deleteButtonToast.test.js && node test/chapterEditorModalAuth.test.js && node test/validators.test.js && node test/api_action.test.js && node test/server_auth.test.js && node test/server_signature.test.js && node test/bookHistory.test.js && node test/useDiscoverBooks.test.js && node test/getListBooks.test.ts && node test/getSearchRelays.test.ts && node test/followedAuthorBackgroundFetch.test.ts && node test/loginClearsSearchCache.test.ts && node test/settings/manageChapters.spec.tsx && node test/settings/offline.spec.tsx && node test/settings/profile.spec.tsx && node test/settings/ui.spec.tsx && node test/settings/relays.spec.tsx && node test/homeFeedFilters.test.ts && node test/publishAnnouncement.test.ts && node test/notificationStore.test.ts && node test/subscriptionPersistence.test.js && node test/pushNotifications.test.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "dev": "vite",
@@ -75,6 +75,7 @@
     "zustand": "^5.0.6",
     "@tanstack/react-query": "^5.60.2",
     "@uiw/react-md-editor": "^4.0.8",
-    "@uiw/react-markdown-preview": "^5.1.5"
+    "@uiw/react-markdown-preview": "^5.1.5",
+    "web-push": "^3.6.7"
   }
 }

--- a/test/pushNotifications.test.js
+++ b/test/pushNotifications.test.js
@@ -1,0 +1,44 @@
+require('ts-node/register');
+const assert = require('assert');
+const {
+  eventHandler,
+  addSubscription,
+  clearSubscriptions,
+  getSubscriptions,
+  webpush,
+  pool,
+} = require('../server');
+
+(async () => {
+  await clearSubscriptions();
+  pool.publish = async () => {};
+  const sub = { endpoint: 'https://example.com', keys: { p256dh: 'p', auth: 'a' } };
+  await addSubscription(sub);
+
+  let calls = 0;
+  webpush.sendNotification = async () => {
+    calls++;
+  };
+
+  const res = { json: () => {}, status: () => res };
+  const event = { kind: 1, created_at: 0, content: '', tags: [] };
+
+  await eventHandler({ body: event }, res);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.strictEqual(calls, 1);
+
+  await clearSubscriptions();
+  await addSubscription(sub);
+  webpush.sendNotification = async () => {
+    const err = new Error('gone');
+    err.statusCode = 410;
+    throw err;
+  };
+
+  await eventHandler({ body: event }, res);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const subs = await getSubscriptions();
+  assert.strictEqual(subs.length, 0);
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- integrate web-push with VAPID keys
- send push notifications to stored subscriptions after publishing actions/events
- remove expired subscriptions and test push flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8fe6c2508331a41a19209d3a3eca