### PR TITLE
feat: make container engine configurable

### DIFF
--- a/scripts/build_and_deploy.sh
+++ b/scripts/build_and_deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# container engine (override with CONTAINER_CLI=docker)
+CONTAINER_CLI=${CONTAINER_CLI:-podman}
+
 # install dependencies
 npm ci
 
@@ -15,9 +18,9 @@ npm test
 # build static files
 npm run build
 
-# build docker image including API server
-docker build -t bookstr:latest .
+# build container image including API server
+$CONTAINER_CLI build -t bookstr:latest .
 
-echo "Docker image 'bookstr:latest' built successfully."
+echo "Container image 'bookstr:latest' built successfully."
 
-echo "Run 'docker run -p 3000:3000 bookstr:latest' to start the container. Set PORT to change the internal server port."
+echo "Run '$CONTAINER_CLI run -p 3000:3000 bookstr:latest' to start the container. Set PORT to change the internal server port."


### PR DESCRIPTION
## Summary
- allow overriding container engine in build script
- use `$CONTAINER_CLI` for build and run commands

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ec4ab5994833189891a3c1769d636