### PR TITLE
Add dev container helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,18 @@ not exist, runs the tests and builds the production bundle.
 Launch the API server and Vite dev server together:
 
 ```bash
-docker compose up
+./scripts/dev-container.sh
 ```
 
-Podman users can run `podman compose up`. The `docker-compose.yml` file omits
-the `version` key for compatibility with both tools.
+The helper script defaults to **Podman**. Set `CONTAINER_CLI=docker` to use
+Docker instead:
+
+```bash
+CONTAINER_CLI=docker ./scripts/dev-container.sh
+```
+
+The `docker-compose.yml` file omits the `version` key for compatibility with
+both tools.
 
 The API server listens on <http://localhost:3000> while the frontend is served
 by Vite on <http://localhost:5173>. Source files are mounted so changes trigger

--- a/scripts/dev-container.sh
+++ b/scripts/dev-container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# container engine detection (override with CONTAINER_CLI)
+ENGINE=${CONTAINER_CLI:-}
+
+if [ -z "$ENGINE" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+  elif command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+  else
+    echo "Neither podman nor docker is installed. Please install one to continue." >&2
+    exit 1
+  fi
+fi
+
+exec "$ENGINE" compose up "$@"


### PR DESCRIPTION
## Summary
- add `dev-container.sh` helper to auto-detect Podman/Docker and run compose
- document helper script usage and Podman default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ec8c5030c83319bbac85bcd16787e