### PR TITLE
Add dev script with correct compose flag order

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# container engine detection (override with CONTAINER_CLI)
+ENGINE=${CONTAINER_CLI:-}
+
+if [ -z "$ENGINE" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+  elif command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+  else
+    echo "Neither podman nor docker is installed. Please install one to continue." >&2
+    exit 1
+  fi
+fi
+
+exec "$ENGINE" compose -f docker-compose.yml up "$@"


### PR DESCRIPTION
## Summary
- add dev script that runs docker or podman compose with `-f docker-compose.yml up`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ed86b579c8331997ac86d5e608a10